### PR TITLE
Standard and Extension: Clearify Words

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -13,7 +13,7 @@ Grid Based Records (Fields)
     - description: Maxwell/field solver
     - allowed values:
       - `Yee` ([doi:10.1109/TAP.1966.1138693](http://dx.doi.org/10.1109/TAP.1966.1138693))
-      - `CK` (*Cole-Karkkainen* type solvers: [doi:10.1016/j.jcp.2011.04.003](http://dx.doi.org/10.1016/j.jcp.2011.04.003), [doi:10.1063/1.168620](http://dx.doi.org/10.1063/1.168620), [doi:10.1109/TAP.2002.801268](http://dx.doi.org/10.1109/TAP.2002.801268); M. Karkkainen et al., *Low-dispersionwake field calculation tools*, ICAP 2006)
+      - `CK` (*Cole-Karkkainen* type solvers: [doi:10.1016/j.jcp.2011.04.003](http://dx.doi.org/10.1016/j.jcp.2011.04.003), [doi:10.1063/1.168620](http://dx.doi.org/10.1063/1.168620), [doi:10.1109/TAP.2002.801268](http://dx.doi.org/10.1109/TAP.2002.801268); M. Karkkainen et al., *Low-dispersion wake field calculation tools*, ICAP 2006)
       - `Lehe` ([doi:10.1103/PhysRevSTAB.16.021301](http://dx.doi.org/10.1103/PhysRevSTAB.16.021301))
       - `DS` (*Directional Splitting* after Yasuhiko Sentoku, [doi:10.1140/epjd/e2014-50162-y](http://dx.doi.org/10.1140/epjd/e2014-50162-y))
       - `PSTD`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -58,7 +58,11 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
   - `basePath`
     - type: *(string)*
     - description: a common prefix for all data sets and sub-groups of a
-                   specific iteration
+                   specific iteration;
+                   this string only indicates *how* the data is stored,
+                   to create a real path from it replace all occurences
+                   of `%T` with the integer value of the iteration, e.g.,
+                   `/data/%T` becomes `/data/100`
     - allowed value: fixed to `/data/%T/` for this version of the standard
 
   - `fieldsPath`
@@ -234,7 +238,7 @@ the vector sub-group as `field record`.
                  `y`, `z` (or respectively `r`, `t`, `z`) are data
                  sets of `scalar` fields.
 
-### Mandatory attributes for each field
+### Mandatory attributes for each `field record`
 
 The following attributes must be stored with the `fieldName` (which is a
 data set attribute for `scalar` or a group attribute for `vector` fields):
@@ -377,7 +381,7 @@ hosts the group-attribute `value` and other mandatory attributes such as
     - type: each component in *(float)*
     - description: component-wise momentum of the attribute
 
-### Mandatory attributes for each particle record
+### Mandatory attributes for each `particle record`
 
 The following attributes must be stored with the `particleName/recordName`
 (which is a data set attribute for a `scalar` particle record or a group


### PR DESCRIPTION
- use "record" for both scalar and vector fields and scalar/vector particle entries
- use "components" for the vector field's data sets
- fix `basePath` for now

Extension: ED-PIC
- move field solver attributes to `fieldPath` since
  they are common for all fields
