### PR TITLE
Fix: Typo Formatting and Might

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -37,19 +37,19 @@ Mesh Based Records (Fields)
   - `fieldSolverParameters`
     - type: *(string)*
     - description: additional parameters for fields solvers
-                   (optional, might be specified further in the future)
+                   (may be specified further in the future)
 
   - `currentSmoothing`
     - type: *(string)*
     - description: applied filters to the current field after the particles'
                    current deposition
-    - note: might become a particle record attribute in the future
+    - note: may becomes a particle record attribute in the future
     - allowed values: same as for `fieldSmoothing`
 
   - `currentSmoothingParameters`
     - type: *(string)*
     - description: required if `currentSmoothing` is not `none`, additional parameters to describe the applied filter further
-    - note: might become a particle record attribute in the future
+    - note: may becomes a particle record attribute in the future
     - allowed values: same as for `fieldSmoothingParameters`
 
   - `chargeCorrection`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,7 +1,7 @@
 The openPMD Standard
 ====================
 
-VERSION: *draft* (April 14th, 2015)
+VERSION: *draft* (August 19th, 2015)
 
 Conventions Throughout this Documents
 --------------------------------------
@@ -14,7 +14,7 @@ All `keywords` in this standard are case-sensitive.
 
 The naming *(float)* without a closer specification is used if the user can
 choose which kind of floating point precision shall be used.
-The naming *(uint)* and *(int) without a closer specification is used if the
+The naming *(uint)* and *(int)* without a closer specification is used if the
 user can choose which kind of (un)signed integer type shall be used.
 The naming for the type *(string)* refers to fixed-length, plain ASCII encoded
 character arrays since they are the only ones that are likely to propagate
@@ -135,7 +135,7 @@ contains the attributes:
     - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"
     - example: `2015-12-02 17:48:42 +0100`
 
-Each group and path might contain the attribute **comment** for general
+Each group and path may contain the attribute **comment** for general
 human-readable documentation, e.g., for features not yet covered by the
 standard:
 
@@ -561,10 +561,10 @@ The base standard defined in this document is sufficient for describing
 
 For specific domains of engineering and science and to allow code
 interoperability, specific conventions are necessary. As an example, some
-records might be of distinct importance and should be read/written with exactly
+records may be of distinct importance and should be read/written with exactly
 the same name or are always required for, e.g., restarts and checkpoints.
 
-Also additional meta information might be useful for publishing the data
+Also additional meta information may be useful for publishing the data
 created by a scientific instrument or simulation, e.g., the focal length
 of a camera objective or the used algorithms in a specific simulation.
 Even if they are not necessary for code-interoperability, an extension


### PR DESCRIPTION
might is the same as may but less likely (and may is defined in [RFC 2119](https://tools.ietf.org/html/rfc2119]))

related but does not close #52 
