### PR TITLE
Close #98 #100 ED-PIC Extension more Descriptions

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -419,10 +419,18 @@ else :
 
 - **Recommended:**
   - `particlePatches`
-    - description: if this record is used in combination with the
-                   `globalCellId` record, the `position` for `offset` and
-                   `extend` refers to the `globalCellId` and not the in-cell
-                   `position`
+    - description: if this record is used in combination with non-constant
+                   components in the `particleOffset` components, the
+                   position for `offset` and `extend` refers to the
+                   position of the beginning of the cell (see `positionOffset`)
+    - advice to implementors: the calculation and description of
+                              `position` and `positionOffset` is as in
+                              the base standard still the same;
+                              for non-constant components in `positionOffset`
+                              (beginning-of-cell representation) one can simply
+                              check `offset` and `extend` against the
+                              `positionOffset` record to select particles
+                              in patches "by cell"
 
 - **Optional:**
   - `id`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -463,7 +463,8 @@ x = position_x_relative + position_x_offset
       - `numParticles`: number of particles in this patch
       - `numParticlesOffset`: offset within the one-dimensional records where
                               the first particle in this patch is stored
-      - `offset`: n-values with positions where the particle patch begins; the
+      - `offset`: n-values with positions where the particle patch begins
+                  (including `particleOffset`s as described above); the
                   order of positions is given in component order
                   `x`[, `y`[, `z`]] of the species' `position` record and `n`
                   by the number of components of `position`
@@ -475,9 +476,9 @@ x = position_x_relative + position_x_offset
                    allows to sub-sort records that are close in the n-dimensional
                    `position` to ensure an intermediate level of data locality;
                    patches of particles must be hyperrectangles regarding
-                   the `position` of the particles within; the union of all
-                   particle patches must resemble all elements in the particle's
-                   records
+                   the `position` (including `particleOffset`s as described
+                   above) of the particles within; the union of all particle
+                   patches must resemble all elements in the particle's records
 
 
 Unit Systems and Dimensionality


### PR DESCRIPTION
~~Please let us merge #101 first~~
### Close #100 ED-PIC Types more Relaxed

types for particle records can be either _(float)_, _(int)_ or _(uint)_ for most of the listed ones (basically: user can choose freely)

see discussion/mentioning here:
    http://git.io/vsBKt

more description + unitDimension for `E` and `B`
### Close #98 Update Description particlePatches

Update with new definitions of `position` and `positionOffset` for the ED-PIC extension.
