### PR TITLE
Typo: Allowed Values for `fieldSmoothing`

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -166,7 +166,7 @@ extension. The individual requirement is given in `scope`.
     - type: *(string)*
     - scope: *required*
     - description: applied field filters for E and B
-    - allowed values: same as for `fieldSmoothing`
+    - allowed values: same as for `currentSmoothing`
 
   - `fieldSmoothingParameters`
     - type: *(string)*


### PR DESCRIPTION
Fixes the reference for allowed values in `fieldSmoothing` (same as in current).

Discovered copy-paste typo by @Flamefire, thanks!
