### PR TITLE
ED-PIC: Fix PSATD Long Name

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -43,9 +43,9 @@ The individual requirement is given in `scope`.
               [doi:10.1140/epjd/e2014-50162-y](http://dx.doi.org/10.1140/epjd/e2014-50162-y))
       - `PSTD` (*Pseudo-Spectral Time Domain*, e.g.,
                 Q. H. Liu, Letters 15 (3) (1997) 158–165)
-      - `PSATD` (*Pseudo-Spectral Time Domain*, I. Haber, R. Lee, H. Klein,
-                 J. Boris, Advances in electromagnetic simulation techniques,
-                 1973)
+      - `PSATD` (*Pseudo-Spectral Analytical Time Domain*, I. Haber, R. Lee,
+                 H. Klein, J. Boris, Advances in electromagnetic simulation
+                 techniques, 1973)
       - `GPSTD`
       - `other`
       - `none`


### PR DESCRIPTION
Fix a copy & paste error in the pseudo-spectral _analytical_ time-domain (PSATD) algorithm description.
