### PR TITLE
Particle Patches: Typo in Reference to positionOffset

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -464,7 +464,7 @@ should be used to push the particle.
 
   - `particlePatches`
     - description: if this sub-group is used in combination with non-constant
-                   components in the `particleOffset` components, the
+                   components in the `positionOffset` components, the
                    position for `offset` and `extent` refers to the
                    position of the beginning of the cell (see `positionOffset`)
     - advice to implementors: the calculation and description of

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -495,7 +495,7 @@ tools to read records with a size of more than the typical size of a
 local-node's RAM, the records in this sub-group allow to sub-sort particle
 records that are close in the n-dimensional `position` to ensure an
 intermediate level of data locality. Patches of particles must be
-hyperrectangles regarding the `position` (including `particleOffset`s as
+hyperrectangles regarding the `position` (including `positionOffset`s as
 described above) of the particles within. The union of all particle patches
 must correspond to the complete particle's records.
 


### PR DESCRIPTION
Corrects as small typo in the base standard and the ED-PIC extension when referring to the particles' `positionOffset`.
