### PR TITLE
Unspecified float/int append X

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -341,7 +341,7 @@ particle. Therefore, this extension requires the two following attributes:
              charge of 100 electrons), then macroweighted must be 1
 
 - `weightingPower`
-  - type: *(double / REAL8)*
+  - type: *(float64 / REAL8)*
   - scope: *required*
   - description: indicates with which power of `weighting` (see below)
                  the quantity should be multiplied, in order to go from the

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -184,20 +184,20 @@ field that should be distributed again on the cells.
 
 - fundamental fields:
   - `E`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the electric field
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
     - advice to implementors: must have
                               `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
                               (V/m = kg * m / (A * s^3))
   - `B`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the magnetic field
     - advice to implementors: must have
                               `unitDimension = (0., 1., -2., -1., 0., 0., 0.)`
                               (T = kg / (A * s^2))
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
 
 - auxiliary fields:
@@ -229,7 +229,7 @@ The following additional attributes are defined in this extension.
 The individual requirement is given in `scope`.
 
   - `particleShape`
-    - type: *(float)*
+    - type: *(floatX)*
     - scope: *required*
     - description: the order of the particle assignment function shape
                    (see *Hockney* reprint 1989, ISBN:0-85274-392-0, table 5-1)
@@ -382,7 +382,7 @@ momentum change due to collisions) but not as *the* particle momentum that
 should be used to push the particle.
 
   - `charge`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: electric charge of the macroparticle or of the underlying
                    individual particle (depending on the `macroWeighted` flag)
     - advice to implementors: must have `weightingPower = 1` and
@@ -390,7 +390,7 @@ should be used to push the particle.
                               (charge = current * time)
 
   - `mass`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: mass of the macroparticle or of the underlying individual
                    particle (depending on the `macroWeighted` flag)
     - advice to implementors: must have `weightingPower = 1` and
@@ -398,7 +398,7 @@ should be used to push the particle.
                               (mass)
 
   - `weighting`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the number of underlying individual particles that
                    the macroparticles represent
     - advice to implementors: must have `weightingPower = 1`,
@@ -406,7 +406,7 @@ should be used to push the particle.
                               `unitDimension == (0., ..., 0.)`
 
   - `momentum/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: component-wise momentum of the macroparticle or of the
                    underlying individual particle (depending on the
                    `macroWeighted` flag)
@@ -415,7 +415,7 @@ should be used to push the particle.
                               (momentum = mass * length / time)
 
   - `position/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: component-wise position of a particle, relative to
                    `positionOffset`
       - in the case where the `component`s of `positionOffset` are constant,
@@ -426,19 +426,19 @@ should be used to push the particle.
         `positionOffset` must represent the position of the beginning of the
         cell (see below)
     - rationale: dividing the particle position in a beginning of the cell
-                 (as *(int)*) and in-cell position (as *(float)*) can
+                 (as *(intX)*) and in-cell position (as *(floatX)*) can
                  dramatically improve the precision of stored particle
                  positions; this division creates a connection between
                  particles and the fields on their cells
     - advice to implementors: must have `weightingPower = 0` and
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (length)
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
     - example: use only `x` and `y` in 2D
 
   - `positionOffset/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: if the `component`s of this record are non-constant
                    this must represent the position of the beginning of the
                    cell the particle is associated with;
@@ -455,7 +455,7 @@ should be used to push the particle.
     - advice to implementors: must have `weightingPower = 0` and
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (length)
-    - advice to implementors: an *(int)* or *(uint)* type is likely the most
+    - advice to implementors: an *(intX)* or *(uintX)* type is likely the most
                               frequent case for this record
     - advice to implementors: if you want to neglect the relation between
                               particles and their cells, simply store this
@@ -477,21 +477,21 @@ should be used to push the particle.
                               in patches "by cell"
 
   - `boundElectrons`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: number of bound electrons of an ion/atom;
                    to provide information to atomic physics algorithms
     - advice to implementors: must have `weightingPower = 1` and
                               `unitDimension = (0., ..., 0.)` (dimensionless)
 
   - `protonNumber`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the atomic number Z of an ion/atom;
                    to provide information to atomic physics algorithms
     - advice to implementors: must have `weightingPower = 1` and
                               `unitDimension = (0., ..., 0.)` (dimensionless)
 
   - `neutronNumber`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the neutron number N = the mass number - A and
                    the atomic number Z of an ion/atom;
                    to provide information to atomic physics algorithms

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -12,10 +12,12 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 All `keywords` in this standard are case-sensitive.
 
-The naming *(floatX)* without a closer specification is used if the implementor
-can choose which kind of floating point precision shall be used.
-The naming *(uintX)* and *(intX)* without a closer specification is used if the
-implementor can choose which kind of (un)signed integer type shall be used.
+The naming *(floatX)* without further specification is used if the implementor
+can choose which kind of floating point precision shall be used
+(e.g. *(float16)*, *(float32)*, *(float64)*, *(float128)*, etc.).
+The naming *(uintX)* and *(intX)* without further specification is used if the
+implementor can choose which kind of (un)signed integer type shall be used
+(e.g. *(int32)*, *(uint64)*, etc.).
 The naming for the type *(string)* refers to fixed-length, plain ASCII encoded
 character arrays since they are the only ones that are likely to propagate
 through all file-format APIs and third-party programs that use them.

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -12,9 +12,9 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 All `keywords` in this standard are case-sensitive.
 
-The naming *(float)* without a closer specification is used if the implementor
+The naming *(floatX)* without a closer specification is used if the implementor
 can choose which kind of floating point precision shall be used.
-The naming *(uint)* and *(int)* without a closer specification is used if the
+The naming *(uintX)* and *(intX)* without a closer specification is used if the
 implementor can choose which kind of (un)signed integer type shall be used.
 The naming for the type *(string)* refers to fixed-length, plain ASCII encoded
 character arrays since they are the only ones that are likely to propagate
@@ -202,7 +202,7 @@ attributes that describe the current time and the last
 time step.
 
  - `time`
-   - type: *(float)*
+   - type: *(floatX)*
    - description: the time corresponding to this iteration. Because at
                   one given iteration, different quantities may be defined
                   at different times (e.g. in a staggered code), this time is
@@ -215,7 +215,7 @@ time step.
               then have a non-zero `timeOffset`.
 
  - `dt`
-   - type: *(float)*
+   - type: *(floatX)*
    - description: The latest time step (that was used to reach this iteration).
                   This is needed at the iteration level, since the time step
                   may vary from iteration to iteration in certain codes.
@@ -367,7 +367,7 @@ meshes):
       - `thetaMode` Fortran-style `A[r,z]` write: `("r", "z")` and `dataOrder='F'`
 
   - `gridSpacing`
-    - type: 1-dimensional array containing N *(float)*
+    - type: 1-dimensional array containing N *(floatX)*
             elements, where N is the number of dimensions in the simulation
     - description: spacing of the grid points along each dimension (in the
                    units of the simulation); this refers to the spacing of the
@@ -398,7 +398,7 @@ The following attributes must be stored with each `scalar record` and each
 *component* of a `vector record`:
 
   - `position`
-    - type: 1-dimensional array of N *(float)* where N is the number of
+    - type: 1-dimensional array of N *(floatX)* where N is the number of
             dimensions in the simulation.
     - range of each value: `[ 0.0 : 1.0 )`
     - description: relative position of the component on the current element of
@@ -442,14 +442,14 @@ short-hand notation (see: *Constant Record Components*).
                    particle.
 
   - `position/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - scope: *required*
     - description: component-wise position of a particle, relative to
                    `positionOffset`
     - example: use only `x` and `y` in 2D, use `x` in 1D
 
   - `positionOffset/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - scope: *required*
     - description: an offset to be added to each element of `position`
     - rationale: for precision reasons and visualization purposes, it is
@@ -529,7 +529,7 @@ patch order:
                             that were stored before this one
 
   - `offset/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: absolute position (`position` + `positionOffset` as defined
                    above) where the particle patch begins:
                    defines the (inclusive) lower bound with positions that are
@@ -537,7 +537,7 @@ patch order:
                    the same requirements as for regular record components apply
 
   - `extent/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: extent of the particle patch; the `offset` + `extent` must
                    be larger than the maximum absolute position of particles in
                    the patch as the exact upper bound of position `offset` +
@@ -602,7 +602,7 @@ Reminder: for scalar records the `record` itself is also the `component`.
                         `(1., 1., -3., -1., 0., 0., 0.)`
 
   - `timeOffset`
-    - type: *(float)*
+    - type: *(floatX)*
     - description: the offset between the time at which this record is
                    defined and the `time` attribute of the `basePath` level.
                    This should be written in the same unit system as `time`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -223,7 +223,7 @@ time step.
                   may vary from iteration to iteration in certain codes.
 
  - `timeUnitSI`
-    - type: *(double / REAL8)*
+    - type: *(float64 / REAL8)*
     - description: a conversation factor to convert `time` and `dt` to `seconds`
     - example: `1.0e-16`
 
@@ -380,7 +380,7 @@ meshes):
                               the axes in `axisLabels`
 
   - `gridGlobalOffset`
-    - type: 1-dimensional array containing N *(double / REAL8)*
+    - type: 1-dimensional array containing N *(float64 / REAL8)*
             elements, where N is the number of dimensions in the simulation
     - description: start of the current domain of the simulation (position of
                    the beginning of the first cell) in simulation units
@@ -390,7 +390,7 @@ meshes):
     - example: `(0.0, 100.0, 0.0)` or `(0.5, 0.5, 0.5)`
 
   - `gridUnitSI`
-    - type: *(double / REAL8)*
+    - type: *(float64 / REAL8)*
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
@@ -567,7 +567,7 @@ attributes must be added:
 Reminder: for scalar records the `record` itself is also the `component`.
 
   - `unitSI`
-    - type: *(double / REAL8*)
+    - type: *(float64 / REAL8*)
     - description: a conversation factor to multiply data with to be
                    represented in SI
     - rationale: can also be used to scale a dimension-less `component`
@@ -578,7 +578,7 @@ Reminder: for scalar records the `record` itself is also the `component`.
 ### Required for each `Record`
 
   - `unitDimension`
-    - type: array of 7 *(double / REAL8)*
+    - type: array of 7 *(float64 / REAL8)*
     - description: powers of the 7 base measures characterizing the record's
                    unit in SI (length L, mass M, time T, electric current I,
                    thermodynamic temperature theta, amount of substance N,


### PR DESCRIPTION
This is a wording change of the openPMD 1.0.0 standard as proposed in #146.

## Description

When we are referring to floating point numbers with unspecified (user-chosen) precision, we use `(floatX)` for `(float16|32|64|128|...)` now to avoid confusion with single precision "C" floats. The same change is added for the type of (unsigned) integers.

Also replaces the usage of C/C++/Python `double` with `float64` for consistency.

## Affected Components

- `base`
- extension: `ED-PIC`

## Logic Changes

No changes introduced.

## Writer Changes

No data writers affected.

## Reader Changes

No data readers affected.

## Data Converter

No data conversion needed.