### PR TITLE
Release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+Changelog for the openPMD Standard
+==================================
+
+1.0.1
+-----
+**Date:** 2017-12-01
+
+Typo and wording changes since the 1.0.0 release.
+
+This release improves wordings, common questions and example snippets.
+Keywords and logic are unchanged and backwards compatible for revision releases.
+
+## Changes to "1.0.0"
+
+### Base Standard
+
+- **backwards compatible changes:**
+  - better examples for `axisLabels` #153
+  - unspecified (user-chosen) `float`/`uint`/`int` are now called `floatX`/`uintX`/`intX` throughout the standard #152
+  - note to store non-openPMD information outside the `basePath` #115
+  - particle position: update python example #119 #127
+  - particle patches: typo in reference to `positionOffset` #135
+
+### Extension
+
+- `ED-PIC`:
+  - **backwards compatible changes:**
+    - `fieldSmoothing`: typo in allowed values #131
+    - `fieldSolver`: typo in PSATD description #133
+    - reference updated to unspecified (user-chosen) `float`/`uint`/`int` as in base standard #152
+
+### Data Converter
+
+No data conversion needed.

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -43,9 +43,9 @@ The individual requirement is given in `scope`.
               [doi:10.1140/epjd/e2014-50162-y](http://dx.doi.org/10.1140/epjd/e2014-50162-y))
       - `PSTD` (*Pseudo-Spectral Time Domain*, e.g.,
                 Q. H. Liu, Letters 15 (3) (1997) 158–165)
-      - `PSATD` (*Pseudo-Spectral Time Domain*, I. Haber, R. Lee, H. Klein,
-                 J. Boris, Advances in electromagnetic simulation techniques,
-                 1973)
+      - `PSATD` (*Pseudo-Spectral Analytical Time Domain*, I. Haber, R. Lee,
+                 H. Klein, J. Boris, Advances in electromagnetic simulation
+                 techniques, 1973)
       - `GPSTD`
       - `other`
       - `none`

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -464,7 +464,7 @@ should be used to push the particle.
 
   - `particlePatches`
     - description: if this sub-group is used in combination with non-constant
-                   components in the `particleOffset` components, the
+                   components in the `positionOffset` components, the
                    position for `offset` and `extent` refers to the
                    position of the beginning of the cell (see `positionOffset`)
     - advice to implementors: the calculation and description of

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -166,7 +166,7 @@ extension. The individual requirement is given in `scope`.
     - type: *(string)*
     - scope: *required*
     - description: applied field filters for E and B
-    - allowed values: same as for `fieldSmoothing`
+    - allowed values: same as for `currentSmoothing`
 
   - `fieldSmoothingParameters`
     - type: *(string)*

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -341,7 +341,7 @@ particle. Therefore, this extension requires the two following attributes:
              charge of 100 electrons), then macroweighted must be 1
 
 - `weightingPower`
-  - type: *(double / REAL8)*
+  - type: *(float64 / REAL8)*
   - scope: *required*
   - description: indicates with which power of `weighting` (see below)
                  the quantity should be multiplied, in order to go from the

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -184,20 +184,20 @@ field that should be distributed again on the cells.
 
 - fundamental fields:
   - `E`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the electric field
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
     - advice to implementors: must have
                               `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
                               (V/m = kg * m / (A * s^3))
   - `B`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the magnetic field
     - advice to implementors: must have
                               `unitDimension = (0., 1., -2., -1., 0., 0., 0.)`
                               (T = kg / (A * s^2))
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
 
 - auxiliary fields:
@@ -229,7 +229,7 @@ The following additional attributes are defined in this extension.
 The individual requirement is given in `scope`.
 
   - `particleShape`
-    - type: *(float)*
+    - type: *(floatX)*
     - scope: *required*
     - description: the order of the particle assignment function shape
                    (see *Hockney* reprint 1989, ISBN:0-85274-392-0, table 5-1)
@@ -382,7 +382,7 @@ momentum change due to collisions) but not as *the* particle momentum that
 should be used to push the particle.
 
   - `charge`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: electric charge of the macroparticle or of the underlying
                    individual particle (depending on the `macroWeighted` flag)
     - advice to implementors: must have `weightingPower = 1` and
@@ -390,7 +390,7 @@ should be used to push the particle.
                               (charge = current * time)
 
   - `mass`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: mass of the macroparticle or of the underlying individual
                    particle (depending on the `macroWeighted` flag)
     - advice to implementors: must have `weightingPower = 1` and
@@ -398,7 +398,7 @@ should be used to push the particle.
                               (mass)
 
   - `weighting`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the number of underlying individual particles that
                    the macroparticles represent
     - advice to implementors: must have `weightingPower = 1`,
@@ -406,7 +406,7 @@ should be used to push the particle.
                               `unitDimension == (0., ..., 0.)`
 
   - `momentum/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: component-wise momentum of the macroparticle or of the
                    underlying individual particle (depending on the
                    `macroWeighted` flag)
@@ -415,7 +415,7 @@ should be used to push the particle.
                               (momentum = mass * length / time)
 
   - `position/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: component-wise position of a particle, relative to
                    `positionOffset`
       - in the case where the `component`s of `positionOffset` are constant,
@@ -426,19 +426,19 @@ should be used to push the particle.
         `positionOffset` must represent the position of the beginning of the
         cell (see below)
     - rationale: dividing the particle position in a beginning of the cell
-                 (as *(int)*) and in-cell position (as *(float)*) can
+                 (as *(intX)*) and in-cell position (as *(floatX)*) can
                  dramatically improve the precision of stored particle
                  positions; this division creates a connection between
                  particles and the fields on their cells
     - advice to implementors: must have `weightingPower = 0` and
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (length)
-    - advice to implementors: a *(float)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
     - example: use only `x` and `y` in 2D
 
   - `positionOffset/` + components such as `x`, `y` and `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: if the `component`s of this record are non-constant
                    this must represent the position of the beginning of the
                    cell the particle is associated with;
@@ -455,7 +455,7 @@ should be used to push the particle.
     - advice to implementors: must have `weightingPower = 0` and
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (length)
-    - advice to implementors: an *(int)* or *(uint)* type is likely the most
+    - advice to implementors: an *(intX)* or *(uintX)* type is likely the most
                               frequent case for this record
     - advice to implementors: if you want to neglect the relation between
                               particles and their cells, simply store this
@@ -477,21 +477,21 @@ should be used to push the particle.
                               in patches "by cell"
 
   - `boundElectrons`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: number of bound electrons of an ion/atom;
                    to provide information to atomic physics algorithms
     - advice to implementors: must have `weightingPower = 1` and
                               `unitDimension = (0., ..., 0.)` (dimensionless)
 
   - `protonNumber`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the atomic number Z of an ion/atom;
                    to provide information to atomic physics algorithms
     - advice to implementors: must have `weightingPower = 1` and
                               `unitDimension = (0., ..., 0.)` (dimensionless)
 
   - `neutronNumber`
-    - type: *(float)* or *(int)* or *(uint)*
+    - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the neutron number N = the mass number - A and
                    the atomic number Z of an ion/atom;
                    to provide information to atomic physics algorithms

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -12,10 +12,12 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 All `keywords` in this standard are case-sensitive.
 
-The naming *(floatX)* without a closer specification is used if the implementor
-can choose which kind of floating point precision shall be used.
-The naming *(uintX)* and *(intX)* without a closer specification is used if the
-implementor can choose which kind of (un)signed integer type shall be used.
+The naming *(floatX)* without further specification is used if the implementor
+can choose which kind of floating point precision shall be used
+(e.g. *(float16)*, *(float32)*, *(float64)*, *(float128)*, etc.).
+The naming *(uintX)* and *(intX)* without further specification is used if the
+implementor can choose which kind of (un)signed integer type shall be used
+(e.g. *(int32)*, *(uint64)*, etc.).
 The naming for the type *(string)* refers to fixed-length, plain ASCII encoded
 character arrays since they are the only ones that are likely to propagate
 through all file-format APIs and third-party programs that use them.

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -428,6 +428,18 @@ short-hand notation (see: *Constant Record Components*).
 
 ### Records for each `Particle Species`
 
+  - `id`
+    - type: *(uint64 / UNSIGNED8)*
+    - scope: *optional*
+    - description: a globally-unique identifying integer for each particle,
+                   that can be used to, e.g., track particles. This
+                   identifying integer should be truly unique within the
+                   simulation; in particular, even among different particle
+                   species, two particles should not have the same id.
+                   Also, when a particle exits the simulation box, its
+                   identifying integer should not be reassigned to a new
+                   particle.
+
   - `position/` + components such as `x`, `y`, `z`
     - type: each component in *(float)* or *(int)* or *(uint)*
     - scope: *required*
@@ -448,37 +460,41 @@ short-hand notation (see: *Constant Record Components*).
                               with `constant record components`
     - example: reading example (with h5py) in Python:
 ```python
-def is_const_record(record, component_name) :
-    return ("value" in record[component_name].attrs.keys())
+import numpy
+import h5py
 
-def get_component(record, component_name) :
-    if is_const_record(record, component_name) :
-        return record[component_name].attrs["value"]
-    else :
-        return record[component_name].value
+
+def is_const_component(record_component):
+    return ("value" in record_component.attrs.keys())
+
+
+def get_component(group, component_name, allocate=False):
+    record_component = group[component_name]
+    unitSI = record_component.attrs["unitSI"]
+
+    if is_const_component(record_component):
+        cvalue = record_component.attrs["value"]
+        if allocate:
+            return cvalue * \
+                numpy.ones(shape=record_component.attrs["shape"],
+                           dtype=record_component.attrs["value"].dtype),
+                unitSI
+        else:
+            return cvalue, unitSI
+    else:
+        return record_component.value, unitSI
+
 
 f = h5py.File('example.h5')
 species = f["<path_to_species_group>"]
 
-position_x_relative = get_component(species["position"], "x") \
-                    * species["position/x"].attrs["unitSI"]
-position_x_offset = get_component(species["positionOffset"], "x") \
-                  * species["positionOffset/x"].attrs["unitSI"]
+position_x_relative, unitXRel = get_component(species, "position/x")
+position_x_offset, unitXOff = get_component(species, "positionOffset/x")
 
-x = position_x_relative + position_x_offset
+x = position_x_relative * unitXRel + \
+    position_x_offset * unitXOff
 ```
 
-  - `id`
-    - type: *(uint64 / UNSIGNED8)*
-    - scope: *optional*
-    - description: a globally-unique identifying integer for each particle,
-                   that can be used to, e.g., track particles. This
-                   identifying integer should be truly unique within the
-                   simulation; in particular, even among different particle
-                   species, two particles should not have the same id.
-                   Also, when a particle exits the simulation box, its
-                   identifying integer should not be reassigned to a new
-                   particle.
 
 ### Sub-Group for each `Particle Species`
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -99,7 +99,18 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
                    to create a real path from it replace all occurrences
                    of `%T` with the integer value of the iteration, e.g.,
                    `/data/%T` becomes `/data/100`
-    - allowed value: fixed to `/data/%T/` for this version of the standard
+    - allowed value: fixed to `/data/%T/` for this version of the
+    standard
+	- remark: all the data that is formatted according to the present
+      standard (i.e. both the meshes and the particles) is to be
+      stored within a path of the form given by `basePath` (e.g. in
+      the above example, the data will be stored within the path `/data/100/`).
+	  If, for various reasons, a user wants to store **additional
+      data** that is not (or cannot be) formatted according to the
+      present standard (e.g. fields on an unstructured mesh),
+      this can be done be storing this data within a path that **is not**
+      of the form given by `basePath` (e.g. `/extra_data`). In this
+      way, the openPMD parsing tools will not parse this additional data. 
 
   - `meshesPath`
     - type: *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -495,7 +495,7 @@ tools to read records with a size of more than the typical size of a
 local-node's RAM, the records in this sub-group allow to sub-sort particle
 records that are close in the n-dimensional `position` to ensure an
 intermediate level of data locality. Patches of particles must be
-hyperrectangles regarding the `position` (including `particleOffset`s as
+hyperrectangles regarding the `position` (including `positionOffset`s as
 described above) of the particles within. The union of all particle patches
 must correspond to the complete particle's records.
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -99,13 +99,12 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
                    to create a real path from it replace all occurrences
                    of `%T` with the integer value of the iteration, e.g.,
                    `/data/%T` becomes `/data/100`
-    - allowed value: fixed to `/data/%T/` for this version of the
-    standard
+    - allowed value: fixed to `/data/%T/` for this version of the standard
 	- remark: all the data that is formatted according to the present
       standard (i.e. both the meshes and the particles) is to be
       stored within a path of the form given by `basePath` (e.g. in
       the above example, the data will be stored within the path `/data/100/`).
-	  If, for various reasons, a user wants to store **additional
+      If, for various reasons, a user wants to store **additional
       data** that is not (or cannot be) formatted according to the
       present standard (e.g. fields on an unstructured mesh),
       this can be done be storing this data within a path that **is not**

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -448,22 +448,22 @@ short-hand notation (see: *Constant Record Components*).
                               with `constant record components`
     - example: reading example (with h5py) in Python:
 ```python
-def is_const_record(record_name, component_name) :
-    return ("value" in record_name[component_name].attrs.keys())
+def is_const_record(record, component_name) :
+    return ("value" in record[component_name].attrs.keys())
 
-def get_component(record_name, component_name) :
-    if is_const_record(record_name, component_name) :
-        return record_name[component_name].attrs["value"]
+def get_component(record, component_name) :
+    if is_const_record(record, component_name) :
+        return record[component_name].attrs["value"]
     else :
-        record_name[component_name].value
+        return record[component_name].value
 
 f = h5py.File('example.h5')
 species = f["<path_to_species_group>"]
 
 position_x_relative = get_component(species["position"], "x") \
-                    * species["position"].attrs["unitSI"]
+                    * species["position/x"].attrs["unitSI"]
 position_x_offset = get_component(species["positionOffset"], "x") \
-                  * species["positionOffset"].attrs["unitSI"]
+                  * species["positionOffset/x"].attrs["unitSI"]
 
 x = position_x_relative + position_x_offset
 ```

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -460,30 +460,17 @@ short-hand notation (see: *Constant Record Components*).
                               with `constant record components`
     - example: reading example (with h5py) in Python:
 ```python
-import numpy
-import h5py
-
-
 def is_const_component(record_component):
     return ("value" in record_component.attrs.keys())
 
-
-def get_component(group, component_name, allocate=False):
+def get_component(group, component_name):
     record_component = group[component_name]
     unitSI = record_component.attrs["unitSI"]
 
     if is_const_component(record_component):
-        cvalue = record_component.attrs["value"]
-        if allocate:
-            return cvalue * \
-                numpy.ones(shape=record_component.attrs["shape"],
-                           dtype=record_component.attrs["value"].dtype),
-                unitSI
-        else:
-            return cvalue, unitSI
+        return record_component.attrs["value"], unitSI
     else:
         return record_component.value, unitSI
-
 
 f = h5py.File('example.h5')
 species = f["<path_to_species_group>"]

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,7 +1,7 @@
 The openPMD Standard
 ====================
 
-VERSION: **1.0.0** (November 11th, 2015)
+VERSION: **1.0.1** (December 1st, 2017)
 
 Conventions Throughout these Documents
 --------------------------------------
@@ -75,7 +75,7 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
     - description: (targeted) version of the format in "MAJOR.MINOR.REVISION",
                    see section "The versions of this standard",
                    minor and revision must not be neglected
-    - example: `1.0.0`
+    - example: `1.0.1`
 
   - `openPMDextension`
     - type: *(uint32)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -100,14 +100,14 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
                    of `%T` with the integer value of the iteration, e.g.,
                    `/data/%T` becomes `/data/100`
     - allowed value: fixed to `/data/%T/` for this version of the standard
-	- remark: all the data that is formatted according to the present
+    - note: all the data that is formatted according to the present
       standard (i.e. both the meshes and the particles) is to be
       stored within a path of the form given by `basePath` (e.g. in
       the above example, the data will be stored within the path `/data/100/`).
-      If, for various reasons, a user wants to store **additional
-      data** that is not (or cannot be) formatted according to the
+      If, for various reasons, a user wants to store *additional
+      data* that is not (or cannot be) formatted according to the
       present standard (e.g. fields on an unstructured mesh),
-      this can be done be storing this data within a path that **is not**
+      this can be done be storing this data within a path that *is not*
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -12,9 +12,9 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 All `keywords` in this standard are case-sensitive.
 
-The naming *(float)* without a closer specification is used if the implementor
+The naming *(floatX)* without a closer specification is used if the implementor
 can choose which kind of floating point precision shall be used.
-The naming *(uint)* and *(int)* without a closer specification is used if the
+The naming *(uintX)* and *(intX)* without a closer specification is used if the
 implementor can choose which kind of (un)signed integer type shall be used.
 The naming for the type *(string)* refers to fixed-length, plain ASCII encoded
 character arrays since they are the only ones that are likely to propagate
@@ -202,7 +202,7 @@ attributes that describe the current time and the last
 time step.
 
  - `time`
-   - type: *(float)*
+   - type: *(floatX)*
    - description: the time corresponding to this iteration. Because at
                   one given iteration, different quantities may be defined
                   at different times (e.g. in a staggered code), this time is
@@ -215,7 +215,7 @@ time step.
               then have a non-zero `timeOffset`.
 
  - `dt`
-   - type: *(float)*
+   - type: *(floatX)*
    - description: The latest time step (that was used to reach this iteration).
                   This is needed at the iteration level, since the time step
                   may vary from iteration to iteration in certain codes.
@@ -367,7 +367,7 @@ meshes):
       - `thetaMode` Fortran-style `A[r,z]` write: `("r", "z")` and `dataOrder='F'`
 
   - `gridSpacing`
-    - type: 1-dimensional array containing N *(float)*
+    - type: 1-dimensional array containing N *(floatX)*
             elements, where N is the number of dimensions in the simulation
     - description: spacing of the grid points along each dimension (in the
                    units of the simulation); this refers to the spacing of the
@@ -398,7 +398,7 @@ The following attributes must be stored with each `scalar record` and each
 *component* of a `vector record`:
 
   - `position`
-    - type: 1-dimensional array of N *(float)* where N is the number of
+    - type: 1-dimensional array of N *(floatX)* where N is the number of
             dimensions in the simulation.
     - range of each value: `[ 0.0 : 1.0 )`
     - description: relative position of the component on the current element of
@@ -442,14 +442,14 @@ short-hand notation (see: *Constant Record Components*).
                    particle.
 
   - `position/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - scope: *required*
     - description: component-wise position of a particle, relative to
                    `positionOffset`
     - example: use only `x` and `y` in 2D, use `x` in 1D
 
   - `positionOffset/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - scope: *required*
     - description: an offset to be added to each element of `position`
     - rationale: for precision reasons and visualization purposes, it is
@@ -529,7 +529,7 @@ patch order:
                             that were stored before this one
 
   - `offset/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: absolute position (`position` + `positionOffset` as defined
                    above) where the particle patch begins:
                    defines the (inclusive) lower bound with positions that are
@@ -537,7 +537,7 @@ patch order:
                    the same requirements as for regular record components apply
 
   - `extent/` + components such as `x`, `y`, `z`
-    - type: each component in *(float)* or *(int)* or *(uint)*
+    - type: each component in *(floatX)* or *(intX)* or *(uintX)*
     - description: extent of the particle patch; the `offset` + `extent` must
                    be larger than the maximum absolute position of particles in
                    the patch as the exact upper bound of position `offset` +
@@ -602,7 +602,7 @@ Reminder: for scalar records the `record` itself is also the `component`.
                         `(1., 1., -3., -1., 0., 0., 0.)`
 
   - `timeOffset`
-    - type: *(float)*
+    - type: *(floatX)*
     - description: the offset between the time at which this record is
                    defined and the `time` attribute of the `basePath` level.
                    This should be written in the same unit system as `time`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -449,13 +449,13 @@ short-hand notation (see: *Constant Record Components*).
     - example: reading example (with h5py) in Python:
 ```python
 def is_const_record(record_name, component_name) :
-    return ("value" in record_name["component_name"].attrs.keys())
+    return ("value" in record_name[component_name].attrs.keys())
 
 def get_component(record_name, component_name) :
     if is_const_record(record_name, component_name) :
-        return record_name["component_name"].attrs["value"]
+        return record_name[component_name].attrs["value"]
     else :
-        record_name["component_name"][:]
+        record_name[component_name].value
 
 f = h5py.File('example.h5')
 species = f["<path_to_species_group>"]

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -256,7 +256,7 @@ the `record` is the `component` (and vice versa).
     - type: *(any type)*
     - data set: `recordName` unique name in group `basePath` +
                 `meshesPath` or alternatively in `basePath` +
-                `particleName` + `particlesPath`
+                `particlesPath` + `particleName`
     - examples:
       - `/data/meshes/temperature`
       - `/data/particles/electrons/charge`

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -223,7 +223,7 @@ time step.
                   may vary from iteration to iteration in certain codes.
 
  - `timeUnitSI`
-    - type: *(double / REAL8)*
+    - type: *(float64 / REAL8)*
     - description: a conversation factor to convert `time` and `dt` to `seconds`
     - example: `1.0e-16`
 
@@ -380,7 +380,7 @@ meshes):
                               the axes in `axisLabels`
 
   - `gridGlobalOffset`
-    - type: 1-dimensional array containing N *(double / REAL8)*
+    - type: 1-dimensional array containing N *(float64 / REAL8)*
             elements, where N is the number of dimensions in the simulation
     - description: start of the current domain of the simulation (position of
                    the beginning of the first cell) in simulation units
@@ -390,7 +390,7 @@ meshes):
     - example: `(0.0, 100.0, 0.0)` or `(0.5, 0.5, 0.5)`
 
   - `gridUnitSI`
-    - type: *(double / REAL8)*
+    - type: *(float64 / REAL8)*
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
@@ -567,7 +567,7 @@ attributes must be added:
 Reminder: for scalar records the `record` itself is also the `component`.
 
   - `unitSI`
-    - type: *(double / REAL8*)
+    - type: *(float64 / REAL8*)
     - description: a conversation factor to multiply data with to be
                    represented in SI
     - rationale: can also be used to scale a dimension-less `component`
@@ -578,7 +578,7 @@ Reminder: for scalar records the `record` itself is also the `component`.
 ### Required for each `Record`
 
   - `unitDimension`
-    - type: array of 7 *(double / REAL8)*
+    - type: array of 7 *(float64 / REAL8)*
     - description: powers of the 7 base measures characterizing the record's
                    unit in SI (length L, mass M, time T, electric current I,
                    thermodynamic temperature theta, amount of substance N,

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -356,14 +356,15 @@ meshes):
     - advice to implementors: in the ordering of variation for the indexes for
                               matrices as defined by the index-operator
                               (`[...][...]`) of the writing code
-    - advice to implementors: query the record's `dataOrder` to get the
+    - advice to implementors: on read, query the record's `dataOrder` to get the
                               information if you need to invert the access to
                               `axisLabels` (and other attributes that use the
                               same definition)
     - examples:
-      - 3D `cartesian`: `("x", "y", "z")` or `("z", "y", "x")`
-      - 2D `cartesian`: `("x", "y")` or `("y", "x")`
-      - `thetaMode`: `("r", "z")` or `("z", "r")`
+      - 3D `cartesian` C-style `A[z,y,x]` write: `("z", "y", "x")` and `dataOrder='C'`
+      - 2D `cartesian` C-style `A[y,x]` write: `("y", "x")` and `dataOrder='C'`
+      - 2D `cartesian` Fortran-style `A[x,y]` write: `("x", "y")` and `dataOrder='F'`
+      - `thetaMode` Fortran-style `A[r,z]` write: `("r", "z")` and `dataOrder='F'`
 
   - `gridSpacing`
     - type: 1-dimensional array containing N *(float)*


### PR DESCRIPTION
This is release 1.0.1 of the openPMD standard.

Typo and wording changes since the 1.0.0 release.

This release improves wordings, common questions and example snippets.
Keywords and logic are unchanged and backwards compatible for revision releases.

## Changes to "1.0.0"

### Base Standard

- **backwards compatible changes:**
  - better examples for `axisLabels` #153
  - unspecified (user-chosen) `float`/`uint`/`int` are now called `floatX`/`uintX`/`intX` throughout the standard #152
  - note to store non-openPMD information outside the `basePath` #115
  - particle position: update python example #119 #127
  - particle patches: typo in reference to `positionOffset` #135

### Extension

- `ED-PIC`:
  - **backwards compatible changes:**
    - `fieldSmoothing`: typo in allowed values #131
    - `fieldSolver`: typo in PSATD description #133
    - reference updated to unspecified (user-chosen) `float`/`uint`/`int` as in base standard #152

### Data Converter

No data conversion needed.