### PR TITLE
Fix meshName: Means mesh record

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -295,7 +295,7 @@ homogenous records, usually in a N-dimensional matrix.
 
 ### Required Attributes for each `mesh record`
 
-The following attributes must be stored additionally with the `meshName` record
+The following attributes must be stored additionally with each `mesh record`
 (which is a data set attribute for `scalar` or a group attribute for `vector`
 meshes):
 


### PR DESCRIPTION
Do not introduce the name `meshName` if it is only used once and actually means "mesh record".

*Implements issue:* #167

## Description

In the base standard, the naming `meshName` was unnecessarily introduced for a simple mesh record without using it later on.

## Affected Components

- `base`

## Logic Changes

None.

## Writer Changes

No effects.

## Reader Changes


No effects.

## Data Converter

No effect, old files are forward compatible to this change.