### PR TITLE
Root Path: Call Group

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -68,7 +68,7 @@ We define the following placeholders and reserved characters:
 **Paths** to **groups** end on `/`, e.g., `/mySubGroup/` and **data sets** end
 without a `/`, e.g., `dataSet` or `/path/to/dataSet`.
 
-Each file's *root* group (path `/`) must at leat contain the attributes:
+Each file's *root* group (path `/`) must at least contain the attributes:
 
   - `openPMD`
     - type: *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -68,7 +68,7 @@ We define the following placeholders and reserved characters:
 **Paths** to **groups** end on `/`, e.g., `/mySubGroup/` and **data sets** end
 without a `/`, e.g., `dataSet` or `/path/to/dataSet`.
 
-Each file's *root* directory (path `/`) must at leat contain the attributes:
+Each file's *root* group (path `/`) must at leat contain the attributes:
 
   - `openPMD`
     - type: *(string)*
@@ -124,7 +124,7 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
                    particle species and the records they include
     - example: `particles/`
 
-It is *recommended* that each file's *root* directory (path `/`) further
+It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:
 
   - `author`
@@ -167,7 +167,7 @@ to a single simulation cycle.)
 
 The chosen style shall not vary within a related set of iterations.
 
-Each file's *root* directory (path `/`) must further define the attributes:
+Each file's *root* group (path `/`) must further define the attributes:
 
   - `iterationEncoding`
     - type: *(string)*


### PR DESCRIPTION
Call the root `/` directory group like all other in-file groups.

*Implements issue:* #160

## Description

At a few initial occasions, the root "path" `/` of a openPMD file was referred to as "directory". We now call it consequently a "group" as in all other places.

Also fixes a typo in "lea**s**t".

## Affected Components

- `base`

## Logic Changes

None.

## Writer Changes

No effects.

## Reader Changes

*How does this change affect data readers?*

No effects.

## Data Converter

No effect, old files are forward compatible to this change.