### PR TITLE
Base Attributes: Software Deps & Machine

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -143,6 +143,21 @@ contains the attributes:
                    file
     - example: `1.2.1`, `80c7551`, `rev42`
 
+  - `softwareDependencies`
+    - type: *(string)*
+    - description: dependencies of `software` that were used when
+                   `software` created the file,
+                   semicolon-separated list in the format `<name>/<version>`
+                   (`<name>` must be without spaces)
+    - example: `gcc/5.4.0;boost/1.66.0;nvcc/9.1;python/3.6;adios/1.13;hdf5/1.8.17`
+
+  - `machine`
+    - type: *(string)*
+    - description: the machine or relevant hardware that created the file;
+                   as semicolon-separated list if needed
+    - example: `summit-ornl` (HPC cluster),
+               `pco.pixelfly-usb` (scientific 14bit CCD camera)
+
   - `date`
     - type: *(string)*
     - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -143,13 +143,22 @@ contains the attributes:
                    file
     - example: `1.2.1`, `80c7551`, `rev42`
 
+  - `date`
+    - type: *(string)*
+    - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"
+    - example: `2015-12-02 17:48:42 +0100`
+
+It is *optional* that each file's *root* group (path `/`) further contains
+the attributes:
+
   - `softwareDependencies`
     - type: *(string)*
     - description: dependencies of `software` that were used when
                    `software` created the file,
-                   semicolon-separated list in the format `<name>/<version>`
-                   (`<name>` must be without spaces)
-    - example: `gcc/5.4.0;boost/1.66.0;nvcc/9.1;python/3.6;adios/1.13;hdf5/1.8.17`
+                   semicolon-separated list
+    - examples:
+      - `gcc@5.4.0;boost@1.66.0;nvcc@9.1;python@3.6;adios@1.13;hdf5@1.8.17`
+      - a long-time archived container image: `registry.example.com/user/repo:version`
 
   - `machine`
     - type: *(string)*
@@ -157,11 +166,6 @@ contains the attributes:
                    as semicolon-separated list if needed
     - example: `summit-ornl` (HPC cluster),
                `pco.pixelfly-usb` (scientific 14bit CCD camera)
-
-  - `date`
-    - type: *(string)*
-    - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"
-    - example: `2015-12-02 17:48:42 +0100`
 
 Each group and data set may contain the attribute **comment** for general
 human-readable documentation, e.g., for features not yet covered by the


### PR DESCRIPTION
Define new base attributes for *software dependencies* and involved *machine*.

- [x] Review: we need to decide if we want to make the new attributes *recommended* (warn if missing) or *optional*. I would favor for *recommended*, since these info are quite important for reproducible science and should be automated. -> *optional*

(*Required* would also be possible but earliest in 2.0 since it would break existing files and might be too strict compared to other base attributes such as `software`. We can also add it as *optional* now and upgrade it to *recommended* in later major versions in case general workflows develop around it from the community.)

*Implements issues:* #116 #137

## Description

The individual software alone is not sufficient for proper documentation and reproducible data creation. We therefore reserve new attributes for both dependencies of the `software` and involved machinery.

For many data files, reproducing how it was created is increasingly complicated. Besides the need to share input, the environment with and on which a software was build can have dramatic influence on the outcome, e.g. due to changes / later discovered bugs in dependencies such as writer libraries or linear algebra libraries, etc.

### Examples

For pythonic-software, the semicolon-joined output of [`pip freeze`](https://pip.pypa.io/en/stable/reference/pip_freeze/) or `conda list --export` would be ~~ideal~~ a good start for the attribute `softwareDependencies`.

On HPC systems, output of `module list` would be a good starting point.

For CMake based builds, the versions of software in a target's `INTERFACE_LINK_LIBRARIES` property could be used to auto-generate a list.

For `machine` the simple `hostname`, the name of a scientific instrument (camera type, etc.) or cluster name are a good value. For hardware-centric projects, also a list of relevant hardware and versioning could be used.

## Affected Components

- `base`

## Logic Changes

None.

## Writer Changes

Writers should (recommended) write the `machine` (e.g. `hostname`) and software dependencies of `software` to new openPMD files now.

We should also update out example files to include the two new attributes:
- [x] [openPMD-validator](https://github.com/openPMD/openPMD-validator/): https://github.com/openPMD/openPMD-validator/pull/31
- [ ] [example files](https://github.com/openPMD/openPMD-example-datasets)

## Reader Changes

No effects besides additional information that *can* be read.

- [x] [openPMD-validator](https://github.com/openPMD/openPMD-validator/): check for the two new attributes and validate their string types: https://github.com/openPMD/openPMD-validator/pull/31

## Data Converter

No effect, old files are forward compatible to this change.