### PR TITLE
meshesPath & particlesPath: optional

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -113,7 +113,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
 
-The following attributes are *optional* in each each file's *root* directory
+The following attributes are *optional* in each each file's *root* group
 (path `/`) and indicate if a file contains mesh and/or particle records. It is
 *required* to set them if one wants to store mesh and/or particle records.
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -113,16 +113,26 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
 
+The following attributes are *optional* in each each file's *root* directory
+(path `/`) and indicate if a file contains mesh and/or particle records. It is
+*required* to set them if one wants to store mesh and/or particle records.
+
   - `meshesPath`
     - type: *(string)*
     - description: path *relative* from the `basePath` to the mesh records
     - example: `meshes/`
+    - note: if this attribute is missing, the file is interpreted as if it
+      contains *no mesh records*! If the attribute is set, the group behind
+      it *must* exist!
 
   - `particlesPath`
     - type: *(string)*
     - description: path *relative* from the `basePath` to the groups for each
                    particle species and the records they include
     - example: `particles/`
+    - note: if this attribute is missing, the file is interpreted as if it
+      contains *no particle records*! If the attribute is set, the group behind
+      it *must* exist!
 
 It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:


### PR DESCRIPTION
Makes the base attributes `meshesPath` and `particlesPath` optional if no meshes or no particles shall be stored. Specifies that the path they describe MUST exist as soon as they are set. If they are unset, this MUST be interpreted as "no respective record".

*Implements issue:*  #143 (cc @mccoys)

## Description

See [comment in the original issue](https://github.com/openPMD/openPMD-standard/issues/143#issuecomment-346833418):

> I propose to introduce the following relaxation and of the two attributes `meshesPath` and `particlesPath`:
> 
> - relax the two attributes from `required` to `optional`
> - in the case an attributes is not set, handle the file as if there are no meshes (particles)
> - define that the path they describe MUST exist if the attributes are set (as most implemented it already like this in 1.0.0 and our validator does this also in a two-liner)

## Affected Components

- `base`

## Logic Changes

if set, same parser logic as before, but it is now required that the path in the attributes is *valid* (does exist as a group).

If unset, interpret as "no particle/mesh" records found, respectively.

## Writer Changes

No effect for before-valid files.

"Work-arounds" for particle-only/mesh-only openPMD files must now make sure that the path in `meshesPath/` or `particlesPath/` does really exist, since that behavior was unspecified so far. If not needed, they are now allowed to skip an attribute.

## Reader Changes

- [x] `openPMD-validator`: relax validator, check path exists if set: https://github.com/openPMD/openPMD-validator/pull/32
- [ ] `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/pull/184 https://github.com/openPMD/openPMD-viewer/issues/186
- [x] `yt`: https://github.com/yt-project/yt/pull/1645
- [ ] `openPMD-visit-plugin`: relaxation of reader needed? cc @xxirii @GBlaclard

## Data Converter

No effect, old files are forward compatible to this change.