### PR TITLE
ED-PIC: Add Pusher Values

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -268,7 +268,12 @@ The individual requirement is given in `scope`.
     - allowed values:
       - `Boris` (J.P. Boris. *Relativistic plasma simulation-optimization of a*
                  *hybrid code.* USA, 1970)
-      - `Vay` ([doi:10.1063/1.2837054](http://dx.doi.org/10.1063/1.2837054))
+      - `Vay` ([doi:10.1063/1.2837054](https://dx.doi.org/10.1063/1.2837054))
+      - `streaming` (constantly moving with initial momentum)
+      - `LLRK4` (reduced Laundau-Lifshitz pusher via RK4 and classical
+                 radiation reaction,
+                 [doi:10.1016/j.cpc.2016.04.002](https://dx.doi.org/10.1016/j.cpc.2016.04.002))
+      - `none` (static particles such as probes)
       - `other`
 
   - `particleInterpolation`

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -269,7 +269,7 @@ The individual requirement is given in `scope`.
       - `Boris` (J.P. Boris. *Relativistic plasma simulation-optimization of a*
                  *hybrid code.* USA, 1970)
       - `Vay` ([doi:10.1063/1.2837054](https://dx.doi.org/10.1063/1.2837054))
-      - `streaming` (constantly moving with initial momentum)
+      - `free-streaming` (constantly moving with initial momentum)
       - `LLRK4` (reduced Laundau-Lifshitz pusher via RK4 and classical
                  radiation reaction,
                  [doi:10.1016/j.cpc.2016.04.002](https://dx.doi.org/10.1016/j.cpc.2016.04.002))


### PR DESCRIPTION
Adds new allowed pusher values for classical radiation reaktion and diagnostics to the `particlePush` attribute in the ED-PIC extensions.

*Implements issues:* #132 #139 #145

## Description

Adds the following new pushers:

- `free-streaming` (constantly moving with initial momentum)
- `LLRK4` (reduced Laundau-Lifshitz pusher via RK4 and classical radiation reaction, [doi:10.1016/j.cpc.2016.04.002](https://dx.doi.org/10.1016/j.cpc.2016.04.002))
- `none` (static particles such as probes)

`none` is a special case of `streaming` but probably still worth to be added to be explicit.

## Affected Components

- `EXT: ED-PIC`

## Logic Changes

None.

## Writer Changes

Writers can now switch from `other` for these three pushers to the newly specified values.

- PIConGPU: https://github.com/ComputationalRadiationPhysics/picongpu/issues/2472

## Reader Changes

Just more allowed values are known now which were previously undefined as `other`.

## Data Converter

Per-application possible but not needed. Old files are still forward compatible to this change.