### PR TITLE
Changelog: 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,42 @@
 Changelog for the openPMD Standard
 ==================================
 
+1.1.0
+-----
+**Date:** 2018-02-06
+
+Base paths for mesh- and particle-only files and updated attributes.
+
+This release defines how to handle files that only contain mesh or particle
+records gracefully. New attributes have been defined to document software
+dependencies and utilized hardware. The ED-PIC extension updated values for
+particle pushers. It further improves wordings for consistency throughout the
+standard.
+
+## Changes to "1.0.1"
+
+### Base Standard
+
+- **minor changes:**
+  - `meshesPath` & `particlesPath`: optional (only when needed) #171
+  - optional attributes to document software dependencies & hardware #170
+    - `softwareDependencies`
+    - `machine`
+- **backwards compatible changes:**
+  - fix wording: `meshName` means `mesh record` #168
+  - fix wording: root path is a "group" as well #169
+
+### Extension
+
+- `ED-PIC`:
+  - **minor changes:**
+    - `particlePush`: additional values defined #172
+
+### Data Converter
+
+No data conversion needed.
+
+
 1.0.1
 -----
 **Date:** 2017-12-01

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to the openPMD standard
 ======================================
 
-The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.0.1/STANDARD.md#the-versions-of-this-standard). This document explains the process by which the standard evolves, and how to contribute to it.
+The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#the-versions-of-this-standard). This document explains the process by which the standard evolves, and how to contribute to it.
 
 Update Cycle
 ------------

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,7 +1,7 @@
 The openPMD Standard
 ====================
 
-VERSION: **1.0.1** (December 1st, 2017)
+VERSION: **1.1.0** (Feburary 6th, 2018)
 
 Conventions Throughout these Documents
 --------------------------------------
@@ -75,7 +75,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
     - description: (targeted) version of the format in "MAJOR.MINOR.REVISION",
                    see section "The versions of this standard",
                    minor and revision must not be neglected
-    - example: `1.0.1`
+    - example: `1.1.0`
 
   - `openPMDextension`
     - type: *(uint32)*


### PR DESCRIPTION
This is the changelog of the 1.1.0 release.

### To Do

- [x] set and update release date
- [x] bump version to `1.1.0` in `STANDARD.md`, ` CONTRIBUTING.md` (3x!)
- [ ] copy to tag message (and GitHub release text) after release