### PR TITLE
Release: 1.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+*Please add a brief description (one sentence) here and link the issue this pull-request implements*
+
+*Implements issue:* #...
+
+## Description
+
+*As detailed description as possible.*
+
+*What is introduced, removed or renamed and why?*
+*What is made required, recommended, optional?*
+*What concept stands behind this change?*
+
+*Please also add an example.*
+
+## Affected Components
+
+- `base`
+- `EXT-...`
+
+## Logic Changes
+
+*Which logic changes are conceptually introduced?*
+
+## Writer Changes
+
+*How does this change affect data writers?*
+*What would a writer need to change?*
+*Does this pull request change the interpretation of existing data writers?*
+
+- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...
+
+## Reader Changes
+
+*How does this change affect data readers?*
+
+*What would a reader need to change? Link implementation examples!*
+
+- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
+- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
+- `yt`: https://github.com/yt-project/yt/...
+- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
+- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...
+- `XDMF` (upcoming): https://github.com/openPMD/openPMD-tools/...
+
+## Data Converter
+
+*How does this affect already existing files with previous versions of the standard?*
+*Is this change possible to be expressed in a way, that an automated tool can update the file?*
+*Link code/pull requests that implement the upgrade logic!*
+
+- https://github.com/openPMD/openPMD-converter/...

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,3 +24,6 @@
 
 ### Reviewers and Substantive Contributions in Later Versions
 
+- David Sagan (Cornell University)
+- Frédéric Pérez (LULI)
+- Fabian Koller (HZDR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,42 @@
 Changelog for the openPMD Standard
 ==================================
 
+1.1.0
+-----
+**Date:** 2018-02-06
+
+Base paths for mesh- and particle-only files and updated attributes.
+
+This release defines how to handle files that only contain mesh or particle
+records gracefully. New attributes have been defined to document software
+dependencies and utilized hardware. The ED-PIC extension updated values for
+particle pushers. It further improves wordings for consistency throughout the
+standard.
+
+## Changes to "1.0.1"
+
+### Base Standard
+
+- **minor changes:**
+  - `meshesPath` & `particlesPath`: optional (only when needed) #171
+  - optional attributes to document software dependencies & hardware #170
+    - `softwareDependencies`
+    - `machine`
+- **backwards compatible changes:**
+  - fix wording: `meshName` means `mesh record` #168
+  - fix wording: root path is a "group" as well #169
+
+### Extension
+
+- `ED-PIC`:
+  - **minor changes:**
+    - `particlePush`: additional values defined #172
+
+### Data Converter
+
+No data conversion needed.
+
+
 1.0.1
 -----
 **Date:** 2017-12-01

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,45 @@
 Contributing to the openPMD standard
 ======================================
 
-Participation
--------------
-
-We participate via *pull requests* on GitHub.
-Improvements will be discussed and adressed in those.
-
-Future proposals and strategies can be discussed in GitHub *issues*.
-
+The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.0.1/STANDARD.md#the-versions-of-this-standard). This document explains the process through which the standard evolves, and how to contribute to it.
 
 Update Cycle
 ------------
 
-New features are discussed and in-cooperated into `upcoming-*` branches.
+The updates of the openPMD standard go through a 3-step process:
 
-Upon agreement on a new version of the standard, a new update
-of the improvements in the according `upcoming` branch is merged on top of the
-`latest` branch and tagged with a new **official version number**.
+- **Issues:** Anyone can propose changes to the standard, request new features,
+ask for clarification, etc. by opening a new issue
+[here](https://github.com/openPMD/openPMD-standard/issues). The proposed
+changes/features/question will then be discussed by the members of the
+openPMD community (or anyone interested, really) in the `Comments` section of
+this issue. The openPMD admins will usually add a label specifying the version
+of the standard in which this should be implemented.
 
+- **Pull requests:** Once an issue is well-understood and a clear solution
+emerges, anyone can volunteer to implement it in the text of the standard. This
+is done by creating a pull request (see below for more details on how to
+create a pull request). Pull requests are then reviewed by the community, and
+eventually merged by the openPMD admins (@ax3l and @RemiLehe) into the
+`upcoming-*` branch (where `*` is replaced by the number of the next upcoming
+version), so that the corresponding changes will be included in the next release.
+
+- **New releases:** Once all the issues that have been labeled for the next
+upcoming version have been resolved (e.g. via pull requests), the openPMD
+admins will create a new official version (by merging the `upcoming-*` on top
+of the `latest` branch and tagging it with a new **official version number**.)
+Tools that use the openPMD standard should then be adapted, so that they can
+properly parse openPMD files that conform to this new official version.
+
+Note that this 3-step process in reflected in the [Projects
+tab](https://github.com/openPMD/openPMD-standard/projects). This page
+lists the upcoming versions that are being considered, and, for each
+upcoming version, tracks the corresponding issues and their status (from
+`proposed` to `accepted` to `implemented`). It is important for
+the prioritization and organization of tasks.
+
+How to implement a change, using a pull request
+-----------------------------------------------
 
 License Model
 -------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,19 @@ in the upper right corner of [this page](https://github.com/openPMD/openPMD-stan
 - Once you are done with the implementation: **push the changes to your fork**:
     `git push -u origin`
 
+- **Create a pull request**:
+    * Point your web browser to `https://github.com/<YourUserName>/openPMD-standard/pulls`, where `<YourUserName>` should be replaced by your Github username.
+    * Click the button `New pull request`
+    * For `base fork`, select `upcoming-*` ; for `head fork` select the name
+    of your new branch.
+    * Click `Create pull request`
+    * In the description section of the pull request, briefly describe the
+    changes that you are making. Please link the Github issue that this is
+    related to. You can use [this template](https://github.com/openPMD/openPMD-standard/blob/upcoming-1.1.0/.github/PULL_REQUEST_TEMPLATE.md) in order to explain how this affects other
+    tools that rely on the openPMD standard.
+    * Click again `Create pull request`
+
+
 License Model
 -------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to the openPMD standard
 ======================================
 
-The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.0.1/STANDARD.md#the-versions-of-this-standard). This document explains the process through which the standard evolves, and how to contribute to it.
+The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.0.1/STANDARD.md#the-versions-of-this-standard). This document explains the process by which the standard evolves, and how to contribute to it.
 
 Update Cycle
 ------------
@@ -31,20 +31,20 @@ of the `latest` branch and tagging it with a new **official version number**.)
 Tools that use the openPMD standard should then be adapted, so that they can
 properly parse openPMD files that conform to this new official version.
 
-Note that this 3-step process in reflected in the [Projects
+Note that this 3-step process is reflected in the [Projects
 tab](https://github.com/openPMD/openPMD-standard/projects). This page
 lists the upcoming versions that are being considered, and, for each
 upcoming version, tracks the corresponding issues and their status (from
-`proposed` to `accepted` to `implemented`). It is important for
+`proposed` to `accepted` to `implemented`). The Projects tab is important for
 the prioritization and organization of tasks.
 
 How to implement a change, through a pull request
 -------------------------------------------------
 
-In order to order to implement a change in the text of the standard,
-and propose it via a pull request, please follow this process (*Note*: this assumes familiarity with `git`.):
+In order to implement a change in the text of the standard,
+please follow this process (*Note*: this assumes familiarity with `git`):
 
-- **Fork the [official repository for the openPMD
+- **Fork the [official repository of the openPMD
 standard](https://github.com/openPMD/openPMD-standard)**.
 ("Forking" means creating a local copy of the official repository, in
 your personal Github account.) This is done by clicking the `Fork` button
@@ -57,8 +57,8 @@ in the upper right corner of [this page](https://github.com/openPMD/openPMD-stan
     * `git fetch mainline` (get latest updates from official repository)
     * `git checkout mainline/upcoming-<versionNumber> -b <newBranch>`: where
     `<versionNumber>` should be replaced by the number of the next upcoming
-    version: see [this
-    page](https://github.com/openPMD/openPMD-standard/branches),
+    version (see [this
+    page](https://github.com/openPMD/openPMD-standard/branches)),
     and where `<newBranch>` should be replaced by a name that is representative
     of the change that you wish to implement.
 
@@ -70,7 +70,7 @@ in the upper right corner of [this page](https://github.com/openPMD/openPMD-stan
 - **Create a pull request**:
     * Point your web browser to `https://github.com/<YourUserName>/openPMD-standard/pulls`, where `<YourUserName>` should be replaced by your Github username.
     * Click the button `New pull request`
-    * For `base fork`, select `upcoming-*` ; for `head fork` select the name
+    * For `base fork`, select `upcoming-*` ; for `head fork`, select the name
     of your new branch.
     * Click `Create pull request`
     * In the description section of the pull request, briefly describe the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,30 +13,37 @@ ask for clarification, etc. by opening a new issue
 [here](https://github.com/openPMD/openPMD-standard/issues). The proposed
 changes/features/question will then be discussed by the members of the
 openPMD community (or anyone interested, really) in the `Comments` section of
-this issue. The openPMD admins will usually add a label specifying the version
-of the standard in which this should be implemented.
+this issue. The openPMD maintainers will usually add a label specifying the
+scope and impact of the change. Also, the maintainers will usually organize
+the issue in the [Projects tab](https://github.com/openPMD/openPMD-standard/projects)
+(see more below), and specify the upcoming version of the standard in which
+this issue should tentatively be implemented. (This may be the next upcoming
+version, or a later one.)
 
 - **Pull requests:** Once an issue is well-understood and a clear solution
 emerges, anyone can volunteer to implement it in the text of the standard. This
 is done by creating a pull request (see below for more details on how to
 create a pull request). Pull requests are then reviewed by the community, and
-eventually merged by the openPMD admins (@ax3l and @RemiLehe) into the
+eventually merged by the openPMD maintainers (@ax3l and @RemiLehe) into the
 `upcoming-*` branch (where `*` is replaced by the number of the next upcoming
 version), so that the corresponding changes will be included in the next release.
 
 - **New releases:** Once all the issues that have been labeled for the next
 upcoming version have been resolved (e.g. via pull requests), the openPMD
-admins will create a new official version (by merging the `upcoming-*` on top
+maintainers will create a new official version (by merging the `upcoming-*` on top
 of the `latest` branch and tagging it with a new **official version number**.)
 Tools that use the openPMD standard should then be adapted, so that they can
 properly parse openPMD files that conform to this new official version.
 
 Note that this 3-step process is reflected in the [Projects
-tab](https://github.com/openPMD/openPMD-standard/projects). This page
+tab](https://github.com/openPMD/openPMD-standard/projects). The Projects tab is important for the prioritization and organization of tasks. It
 lists the upcoming versions that are being considered, and, for each
 upcoming version, tracks the corresponding issues and their status (from
-`proposed` to `accepted` to `implemented`). The Projects tab is important for
-the prioritization and organization of tasks.
+`proposed` to `accepted` to `implemented`). Note that issues evolve and can be
+postponed for later releases, or sometimes even dismissed.
+(It does *not* mean that the issue is bad or irrelevant, but rather e.g.
+that no clear solution emerged yet, or that a solution exists but does not
+benefit from being standardized in openPMD.)
 
 How to implement a change, through a pull request
 -------------------------------------------------
@@ -78,6 +85,9 @@ in the upper right corner of [this page](https://github.com/openPMD/openPMD-stan
     related to. You can use [this template](https://github.com/openPMD/openPMD-standard/blob/upcoming-1.1.0/.github/PULL_REQUEST_TEMPLATE.md) in order to explain how this affects other
     tools that rely on the openPMD standard.
     * Click again `Create pull request`
+
+Note that pull request should only be created for the **next** upcoming version.
+In other words, we only work on **one** version/release of the standard at a given time.
 
 
 License Model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ this issue should tentatively be implemented. (This may be the next upcoming
 version, or a later one.)
 
 - **Pull requests:** Once an issue is well-understood and a clear solution
-emerges, anyone can volunteer to implement it in the text of the standard. This
-is done by creating a pull request (see below for more details on how to
+emerges, anyone can volunteer (via a comment in the issue)
+to implement it in the text of the standard. This is 
+then done by creating a pull request (see below for more details on how to
 create a pull request). Pull requests are then reviewed by the community, and
 eventually merged by the openPMD maintainers (@ax3l and @RemiLehe) into the
 `upcoming-*` branch (where `*` is replaced by the number of the next upcoming

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to the openPMD standard
 ======================================
 
-The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.0.1/STANDARD.md#the-versions-of-this-standard). This document explains the process by which the standard evolves, and how to contribute to it.
+The openPMD standard can evolve in order to accommodate the needs of the community. This results in successive [*versions* of the standard](https://github.com/openPMD/openPMD-standard/blob/1.1.0/STANDARD.md#the-versions-of-this-standard). This document explains the process by which the standard evolves, and how to contribute to it.
 
 Update Cycle
 ------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,34 @@ upcoming version, tracks the corresponding issues and their status (from
 `proposed` to `accepted` to `implemented`). It is important for
 the prioritization and organization of tasks.
 
-How to implement a change, using a pull request
------------------------------------------------
+How to implement a change, through a pull request
+-------------------------------------------------
+
+In order to order to implement a change in the text of the standard,
+and propose it via a pull request, please follow this process (*Note*: this assumes familiarity with `git`.):
+
+- **Fork the [official repository for the openPMD
+standard](https://github.com/openPMD/openPMD-standard)**.
+("Forking" means creating a local copy of the official repository, in
+your personal Github account.) This is done by clicking the `Fork` button
+in the upper right corner of [this page](https://github.com/openPMD/openPMD-standard).
+
+ - **Clone the fork to your local computer, and a create a new branch**:
+    * `git clone git@github.com:<YourUserName>/openPMD-standard.git`
+    * `cd openPMD-standard`
+    * `git remote add mainline git@github.com:openPMD/openPMD-standard.git` (add the official repository for updates)
+    * `git fetch mainline` (get latest updates from official repository)
+    * `git checkout mainline/upcoming-<versionNumber> -b <newBranch>`: where
+    `<versionNumber>` should be replaced by the number of the next upcoming
+    version: see [this
+    page](https://github.com/openPMD/openPMD-standard/branches),
+    and where `<newBranch>` should be replaced by a name that is representative
+    of the change that you wish to implement.
+
+- **Implement changes in the files, and commit them using `git`**
+
+- Once you are done with the implementation: **push the changes to your fork**:
+    `git push -u origin`
 
 License Model
 -------------

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -268,7 +268,12 @@ The individual requirement is given in `scope`.
     - allowed values:
       - `Boris` (J.P. Boris. *Relativistic plasma simulation-optimization of a*
                  *hybrid code.* USA, 1970)
-      - `Vay` ([doi:10.1063/1.2837054](http://dx.doi.org/10.1063/1.2837054))
+      - `Vay` ([doi:10.1063/1.2837054](https://dx.doi.org/10.1063/1.2837054))
+      - `streaming` (constantly moving with initial momentum)
+      - `LLRK4` (reduced Laundau-Lifshitz pusher via RK4 and classical
+                 radiation reaction,
+                 [doi:10.1016/j.cpc.2016.04.002](https://dx.doi.org/10.1016/j.cpc.2016.04.002))
+      - `none` (static particles such as probes)
       - `other`
 
   - `particleInterpolation`

--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -269,7 +269,7 @@ The individual requirement is given in `scope`.
       - `Boris` (J.P. Boris. *Relativistic plasma simulation-optimization of a*
                  *hybrid code.* USA, 1970)
       - `Vay` ([doi:10.1063/1.2837054](https://dx.doi.org/10.1063/1.2837054))
-      - `streaming` (constantly moving with initial momentum)
+      - `free-streaming` (constantly moving with initial momentum)
       - `LLRK4` (reduced Laundau-Lifshitz pusher via RK4 and classical
                  radiation reaction,
                  [doi:10.1016/j.cpc.2016.04.002](https://dx.doi.org/10.1016/j.cpc.2016.04.002))

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,7 +1,7 @@
 The openPMD Standard
 ====================
 
-VERSION: **1.0.1** (December 1st, 2017)
+VERSION: **1.1.0** (Feburary 6th, 2018)
 
 Conventions Throughout these Documents
 --------------------------------------
@@ -75,7 +75,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
     - description: (targeted) version of the format in "MAJOR.MINOR.REVISION",
                    see section "The versions of this standard",
                    minor and revision must not be neglected
-    - example: `1.0.1`
+    - example: `1.1.0`
 
   - `openPMDextension`
     - type: *(uint32)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -113,7 +113,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
 
-The following attributes are *optional* in each each file's *root* directory
+The following attributes are *optional* in each each file's *root* group
 (path `/`) and indicate if a file contains mesh and/or particle records. It is
 *required* to set them if one wants to store mesh and/or particle records.
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -68,7 +68,7 @@ We define the following placeholders and reserved characters:
 **Paths** to **groups** end on `/`, e.g., `/mySubGroup/` and **data sets** end
 without a `/`, e.g., `dataSet` or `/path/to/dataSet`.
 
-Each file's *root* group (path `/`) must at leat contain the attributes:
+Each file's *root* group (path `/`) must at least contain the attributes:
 
   - `openPMD`
     - type: *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -143,6 +143,21 @@ contains the attributes:
                    file
     - example: `1.2.1`, `80c7551`, `rev42`
 
+  - `softwareDependencies`
+    - type: *(string)*
+    - description: dependencies of `software` that were used when
+                   `software` created the file,
+                   semicolon-separated list in the format `<name>/<version>`
+                   (`<name>` must be without spaces)
+    - example: `gcc/5.4.0;boost/1.66.0;nvcc/9.1;python/3.6;adios/1.13;hdf5/1.8.17`
+
+  - `machine`
+    - type: *(string)*
+    - description: the machine or relevant hardware that created the file;
+                   as semicolon-separated list if needed
+    - example: `summit-ornl` (HPC cluster),
+               `pco.pixelfly-usb` (scientific 14bit CCD camera)
+
   - `date`
     - type: *(string)*
     - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -143,13 +143,22 @@ contains the attributes:
                    file
     - example: `1.2.1`, `80c7551`, `rev42`
 
+  - `date`
+    - type: *(string)*
+    - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"
+    - example: `2015-12-02 17:48:42 +0100`
+
+It is *optional* that each file's *root* group (path `/`) further contains
+the attributes:
+
   - `softwareDependencies`
     - type: *(string)*
     - description: dependencies of `software` that were used when
                    `software` created the file,
-                   semicolon-separated list in the format `<name>/<version>`
-                   (`<name>` must be without spaces)
-    - example: `gcc/5.4.0;boost/1.66.0;nvcc/9.1;python/3.6;adios/1.13;hdf5/1.8.17`
+                   semicolon-separated list
+    - examples:
+      - `gcc@5.4.0;boost@1.66.0;nvcc@9.1;python@3.6;adios@1.13;hdf5@1.8.17`
+      - a long-time archived container image: `registry.example.com/user/repo:version`
 
   - `machine`
     - type: *(string)*
@@ -157,11 +166,6 @@ contains the attributes:
                    as semicolon-separated list if needed
     - example: `summit-ornl` (HPC cluster),
                `pco.pixelfly-usb` (scientific 14bit CCD camera)
-
-  - `date`
-    - type: *(string)*
-    - description: date of creation in format "YYYY-MM-DD HH:mm:ss tz"
-    - example: `2015-12-02 17:48:42 +0100`
 
 Each group and data set may contain the attribute **comment** for general
 human-readable documentation, e.g., for features not yet covered by the

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -68,7 +68,7 @@ We define the following placeholders and reserved characters:
 **Paths** to **groups** end on `/`, e.g., `/mySubGroup/` and **data sets** end
 without a `/`, e.g., `dataSet` or `/path/to/dataSet`.
 
-Each file's *root* directory (path `/`) must at leat contain the attributes:
+Each file's *root* group (path `/`) must at leat contain the attributes:
 
   - `openPMD`
     - type: *(string)*
@@ -124,7 +124,7 @@ Each file's *root* directory (path `/`) must at leat contain the attributes:
                    particle species and the records they include
     - example: `particles/`
 
-It is *recommended* that each file's *root* directory (path `/`) further
+It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:
 
   - `author`
@@ -167,7 +167,7 @@ to a single simulation cycle.)
 
 The chosen style shall not vary within a related set of iterations.
 
-Each file's *root* directory (path `/`) must further define the attributes:
+Each file's *root* group (path `/`) must further define the attributes:
 
   - `iterationEncoding`
     - type: *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -295,7 +295,7 @@ homogenous records, usually in a N-dimensional matrix.
 
 ### Required Attributes for each `mesh record`
 
-The following attributes must be stored additionally with the `meshName` record
+The following attributes must be stored additionally with each `mesh record`
 (which is a data set attribute for `scalar` or a group attribute for `vector`
 meshes):
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -113,16 +113,26 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
 
+The following attributes are *optional* in each each file's *root* directory
+(path `/`) and indicate if a file contains mesh and/or particle records. It is
+*required* to set them if one wants to store mesh and/or particle records.
+
   - `meshesPath`
     - type: *(string)*
     - description: path *relative* from the `basePath` to the mesh records
     - example: `meshes/`
+    - note: if this attribute is missing, the file is interpreted as if it
+      contains *no mesh records*! If the attribute is set, the group behind
+      it *must* exist!
 
   - `particlesPath`
     - type: *(string)*
     - description: path *relative* from the `basePath` to the groups for each
                    particle species and the records they include
     - example: `particles/`
+    - note: if this attribute is missing, the file is interpreted as if it
+      contains *no particle records*! If the attribute is set, the group behind
+      it *must* exist!
 
 It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:


### PR DESCRIPTION
This is release 1.1.0 of the openPMD standard.

Base paths for mesh- and particle-only files and updated attributes.

This release defines how to handle files that only contain mesh or particle
records gracefully. New attributes have been defined to document software
dependencies and utilized hardware. The ED-PIC extension updated values for
particle pushers. It further improves wordings for consistency throughout the
standard.

## Changes to "1.0.1"

### Base Standard

- **minor changes:**
  - `meshesPath` & `particlesPath`: optional (only when needed) #171
  - optional attributes to document software dependencies & hardware #170
    - `softwareDependencies`
    - `machine`
- **backwards compatible changes:**
  - fix wording: `meshName` means `mesh record` #168
  - fix wording: root path is a "group" as well #169

### Extension

- `ED-PIC`:
  - **minor changes:**
    - `particlePush`: additional values defined #172

### Data Converter

No data conversion needed.