### PR TITLE
ED-PIC: Fix Formatting Python

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -362,7 +362,7 @@ particle. Therefore, this extension requires the two following attributes:
                             absolutely necessary, reading the additional
                             `weighting` record can be avoided for performance
                             reasons like this:
-  ```python
+```python
 f = h5py.File('example.h5')
 species = f["<path_to_species_group>"]
 q = species["charge"][:]


### PR DESCRIPTION
For formatting code for Python code snippet in ED-PIC extension.

## Description

Just a minor formatting error that disturbs the rendered representation of the file on GitHub.

## Affected Components

- `EXT: ED-PIC`

## Logic Changes

None.

## Writer Changes

None.

## Reader Changes

None.

## Data Updater

None needed.
