### PR TITLE
openPMDextension: Replace ID with String

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -3,8 +3,6 @@ Domain-Specific Naming Conventions for Electro-Dynamic/Static PIC Codes
 
 openPMD extension name: `ED-PIC`
 
-openPMD extension ID: `1`
-
 
 Introduction
 ------------

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -77,22 +77,6 @@ Each file's *root* group (path `/`) must at least contain the attributes:
                    minor and revision must not be neglected
     - example: `1.1.0`
 
-  - `openPMDextension`
-    - type: *(uint32)*
-    - description: the bit-mask of unique IDs of applied extensions of the
-                   openPMD standard
-                   (see: *Domain-Specific Extensions*);
-                   to test for a specific extension `ID` perform a bit-wise
-                   `AND` operation on `openPMDextension`:
-                   `extension_1_used = (( openPMDextension AND ID ) == ID)`
-    - note: if only one extension is used at a time, the value for
-            `openPMDextension` is simply the `ID` of the extension
-    - examples:
-      - `0`: only the base standard is used
-      - `1`: the base standard and the extension with ID `1` apply for the file
-      - general case (discouraged in this version of the standard):
-             `openPMDextension=0 OR <ID1> OR <ID2> OR <...>` (bit-wise `OR`)
-
   - `basePath`
     - type: *(string)*
     - description: a common prefix for all data sets and sub-groups of a
@@ -112,6 +96,27 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       this can be done be storing this data within a path that *is not*
       of the form given by `basePath` (e.g. `/extra_data`). In this
       way, the openPMD parsing tools will not parse this additional data. 
+
+The following attribute is *optional* in each each file's *root* group
+(path `/`) and indicates if a file also follows an openPMD extension
+(see: *Domain-Specific Extensions*) on top of the base standard. It is
+*required* to set them if one wants to declare an openPMD extension.
+
+  - `openPMDextension`
+    - type: *(string)*
+    - description: the unique openPMD extension name of applied extensions on
+                   top of the openPMD base standard
+                   (see: *Domain-Specific Extensions*);
+                   multiple extensions can be activated at the same time and
+                   must appear as semicolon-separated list
+    - note: do not create this attribute if no extension is used
+    - note: if only one extension is used at a time, the value for
+            `openPMDextension` is simply the name of the extension
+    - examples:
+      - `ED-PIC`: the base standard and the extension with name `ED-PIC` apply
+                  for the file
+      - `ED-PIC;SpeciesType`: the base standard and the extensions `ED-PIC` and
+                              `SpeciesType` are used
 
 The following attributes are *optional* in each each file's *root* group
 (path `/`) and indicate if a file contains mesh and/or particle records. It is


### PR DESCRIPTION
Replaces the `openPMDextension` attribute with a semicolor-separated list of strings of names.

*Implements issue:*  #151

cc: @t184256 

## Description

This improves readability and does not cost much at runtime. The change both affects the *base standard* and the only extension in `1.1.X`: `ED-PIC`.

Additionally, the attribute is now *optional*, so one only needs to set it if one really wants to use extensions.

## Affected Components

- `base`
- `EXT: ED-PIC`

## Logic Changes

For the pure use of the base standard, this attribute must be skipped.

Instead of a bitmask one now has to write a semicolon-separated list of names in the `openPMDextension` attribute, e.g.:
```python
enable_extensions = ['ED-PIC', 'SpeciesType']

# h5py group
group.attrs["openPMDextension"] = np.string_(';'.join(extensions))
```

## Writer Changes

Writers **must** skip the attribute now if they are not using extensions.

## Reader Changes

Readers **must** check now if the attribute `openPMDextension` exists at all.
If it exists, splitting the resulting string by `;` will lead to a list of names.
These names are the openPMD extensions.

*What would a reader need to change?*

- [x] `openPMD-validator`: https://github.com/openPMD/openPMD-validator/pull/36
- [ ] `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer
- [ ] `yt`: https://github.com/yt-project/yt
- [ ] `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `openPMD-api`: https://github.com/openPMD/openPMD-api/projects/1

## Data Updater

*How does this affect already existing files with previous versions of the standard?*

Since `openPMDextension` was required before, all existing files are affected.

*Is this change possible to be expressed in a way, that an automated tool can update the file?*

- [x] The `openPMD-updater` script already implements the update logic in:

[`openpmd_updater/transforms/v2_0_0/ExtensionString.py`](https://github.com/openPMD/openPMD-updater/blob/9c59cc7af40431f46d5df5955bf7a25a7529e60d/openpmd_updater/transforms/v2_0_0/ExtensionString.py)
