### PR TITLE
Remove proton/neutron Number

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -226,6 +226,10 @@ Particle Records (Macroparticles)
 The following additional attributes are defined in this extension.
 The individual requirement is given in `scope`.
 
+Note that the attributes below to not include information about the species
+type (e.g. electrons, Helium 4, etc.). Please use the [SpeciesType
+extension](EXT_SpeciesType.md) in order to include this type of information.
+
   - `particleShape`
     - type: *(floatX)*
     - scope: *required*
@@ -482,21 +486,6 @@ should be used to push the particle.
   - `boundElectrons`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: number of bound electrons of an ion/atom;
-                   to provide information to atomic physics algorithms
-    - advice to implementors: must have `weightingPower = 1` and
-                              `unitDimension = (0., ..., 0.)` (dimensionless)
-
-  - `protonNumber`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: the atomic number Z of an ion/atom;
-                   to provide information to atomic physics algorithms
-    - advice to implementors: must have `weightingPower = 1` and
-                              `unitDimension = (0., ..., 0.)` (dimensionless)
-
-  - `neutronNumber`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: the neutron number N = the mass number - A and
-                   the atomic number Z of an ion/atom;
                    to provide information to atomic physics algorithms
     - advice to implementors: must have `weightingPower = 1` and
                               `unitDimension = (0., ..., 0.)` (dimensionless)


### PR DESCRIPTION
This removes the proton/neutron number from the `ED-PIC` extension, since it is now possible to specify it with `SpeciesType`.

*Implements issue:* Close #191

## Affected Components

- `EXT_ED-PIC`

## Logic Changes

Expressing ions in `ED-PIC` can now be done by using the `SpeciesType` extension.

## Writer Changes

Data writers that were writing the proton/neutron number should now use the `SpeciesType` extension.

This might require a lookup of an *element name* in the periodic table for the naming. Previously, one could just define two numbers without knowing how an ion/isotope is abbreviated in the periodic table.

## Reader Changes

I am not aware of any reader that currently checks this attribute, but in theory data readers should now look at the `SpeciesType` information.

- [x] `openPMD-validator`: remove check in `ED-PIC` https://github.com/openPMD/openPMD-validator/pull/39

## Data Converter

Data converters should switch to using the `SpeciesType`.

- [ ] https://github.com/openPMD/openPMD-updater