### PR TITLE
GridSpacing: Per-Component UnitSI & UnitDimension

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -95,7 +95,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       present standard (e.g. fields on an unstructured mesh),
       this can be done be storing this data within a path that *is not*
       of the form given by `basePath` (e.g. `/extra_data`). In this
-      way, the openPMD parsing tools will not parse this additional data.
+      way, the openPMD data readers will not parse this additional data.
 
 The following attribute is *optional* in each each file's *root* group
 (path `/`) and indicates if a file also follows an openPMD extension
@@ -425,7 +425,7 @@ meshes):
 
   - `gridUnitSI`
     - type: 1-dimensional array containing N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation
+            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from fastest to slowest varying index of the described mesh.
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
@@ -433,7 +433,7 @@ meshes):
 
   - `gridUnitDimension`
     - type: array of 7 N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation
+            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from fastest to slowest varying index of the described mesh.
     - description: powers of the 7 base measures characterizing the
             grid axes's dimensions (length L, mass M, time T,
             electric current I, thermodynamic temperature theta,
@@ -441,12 +441,13 @@ meshes):
     - note: this is similar to `unitDimension`, but applies to each axis
         The 7 numbers characterizing the dimension of an axis are stored
         contiguously in this 1D array.
-    - examples:
+    - examples (with `L`, `M` and `T` as defined in `unitDimension`)
         - For a 2D spatial grid (`L=1`), store array
         `(1., 0., 0., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0.)`
-        - For a 2D phase space (Unit "m" along the first axis
-        and "kg.m.s-1" along the second axis), store array
+        - For a 2D phase space (Dimension "L" along the first axis
+        and "L*M/T" along the second axis), store array
         `(1., 0., 0., 0., 0., 0., 0., 1., 1., -1., 0., 0., 0., 0. )`
+
 
 The following attributes must be stored with each `scalar record` and each
 *component* of a `vector record`:

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -431,7 +431,7 @@ on Unit Systems and Dimensionality, further below):
 
   - `gridUnitSI`
     - type: 1-dimensional array containing N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from fastest to slowest varying index of the described mesh.
+            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from slowest to fastest varying index of the described mesh.
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
@@ -439,7 +439,7 @@ on Unit Systems and Dimensionality, further below):
 
   - `gridUnitDimension`
     - type: array of 7 N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from fastest to slowest varying index of the described mesh.
+            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from slowest to fastest varying index of the described mesh.
     - description: powers of the 7 base measures characterizing the
             grid axes's dimensions (length L, mass M, time T,
             electric current I, thermodynamic temperature theta,

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -431,15 +431,17 @@ on Unit Systems and Dimensionality, further below):
 
   - `gridUnitSI`
     - type: 1-dimensional array containing N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from slowest to fastest varying index of the described mesh.
+            elements, where N is the number of dimensions in the simulation.
+            The order of the N values must be identical to the axes in `axisLabels`.
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
     - example: `(1.0e-9, 1.0e-9, 1.0e-6)`
 
   - `gridUnitDimension`
-    - type: array of 7 N *(float64 / REAL8)*
-            elements, where N is the number of dimensions in the simulation. Dimensions shall be ordered from slowest to fastest varying index of the described mesh.
+    - type: 1-dimensional array of 7 N *(float64 / REAL8)*
+            elements, where N is the number of dimensions in the simulation.
+            The order of the N 7-value arrays must be identical to the axes in `axisLabels`.
     - description: powers of the 7 base measures characterizing the
             grid axes's dimensions (length L, mass M, time T,
             electric current I, thermodynamic temperature theta,

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -95,7 +95,7 @@ Each file's *root* group (path `/`) must at least contain the attributes:
       present standard (e.g. fields on an unstructured mesh),
       this can be done be storing this data within a path that *is not*
       of the form given by `basePath` (e.g. `/extra_data`). In this
-      way, the openPMD parsing tools will not parse this additional data. 
+      way, the openPMD parsing tools will not parse this additional data.
 
 The following attribute is *optional* in each each file's *root* group
 (path `/`) and indicates if a file also follows an openPMD extension
@@ -424,11 +424,29 @@ meshes):
     - example: `(0.0, 100.0, 0.0)` or `(0.5, 0.5, 0.5)`
 
   - `gridUnitSI`
-    - type: *(float64 / REAL8)*
+    - type: 1-dimensional array containing N *(float64 / REAL8)*
+            elements, where N is the number of dimensions in the simulation
     - description: unit-conversion factor to multiply each value in
                    `gridSpacing` and `gridGlobalOffset`, in order to convert
                    from simulation units to SI units
-    - example: `1.0e-9`
+    - example: `(1.0e-9, 1.0e-9, 1.0e-6)`
+
+  - `gridUnitDimension`
+    - type: array of 7 N *(float64 / REAL8)*
+            elements, where N is the number of dimensions in the simulation
+    - description: powers of the 7 base measures characterizing the
+            grid axes's dimensions (length L, mass M, time T,
+            electric current I, thermodynamic temperature theta,
+            amount of substance N, luminous intensity J)
+    - note: this is similar to `unitDimension`, but applies to each axis
+        The 7 numbers characterizing the dimension of an axis are stored
+        contiguously in this 1D array.
+    - examples:
+        - For a 2D spatial grid (`L=1`), store array
+        `(1., 0., 0., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0.)`
+        - For a 2D phase space (Unit "m" along the first axis
+        and "kg.m.s-1" along the second axis), store array
+        `(1., 0., 0., 0., 0., 0., 0., 1., 1., -1., 0., 0., 0., 0. )`
 
 The following attributes must be stored with each `scalar record` and each
 *component* of a `vector record`:


### PR DESCRIPTION
*Implements issue:* Close #122 

## Description

This allows meshes to have axes with different dimensions (e.g. for phase space data where one axis is a position, and the second axis is a momentum.)

*What is introduced, removed or renamed and why?*

The attributes `gridUnitDimension` and `gridUnitSI` are now `N` times longer, where `N` is the dimension of the mesh.
In particular `gridUnitDimension` is a 1D array of length `7*N`. This was preferred over a 2D array of dimension `(N,7)` since it seems that `h5py` does not support multidimensional arrays as attributes. 

## Affected Components

- `base`: All mesh data

## Writer Changes

*How does this change affect data writers?*
Data writers should now write the longer array for `gridUnitSI` and add `gridUnitDimension`.

**Note:**  We could make this backward compatible by saying that, if the writer wrote the previous short-array format, then this applies to each axis... @ax3l Is this worth it or too confusing. -> too confusing, we have the updater for that :)

- `openPMD-api` (upcoming): https://github.com/openPMD/openPMD-api/...

## Reader Changes

*How does this change affect data readers?*
Data readers should now extract the dimension of each axis.

- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/pull/40

## Data Converter

*How does this affect already existing files with previous versions of the standard?*
For existing attributes should be duplicated `N` times, in order to convert to the new format.

- [x] https://github.com/openPMD/openPMD-updater/pull/7