### PR TITLE
Mesh: Remove Data Order

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -366,41 +366,29 @@ meshes):
                         the *imaginary* part)
                        ![definition of imaginary part](img/cylindrical.png)
 
-  - `dataOrder`
-    - type: *(string)*
-    - description: used for the reading of 1-dimensional arrays of N elements,
-                   where N is the number of dimensions in the simulation;
-                   these should be in the ordering of variation for the indexes
-                   for matrices as defined by the index-operator (`[...][...]`)
-                   of the writing code; can be omitted for 1D records
-    - rationale: in Fortran, ordering of matrices is linearized in memory in
-                 column-major order whereas in C it is row-major; due to that
-                 the index-operators in Fortran and C operate in exactly
-                 opposite order;
-                 supported file-formats keep the order of the writing code's
-                 record components; we still need to store additional
-                 information such as `axisLabels` in a defined order
-    - allowed values:
-      - `C` if data is written by C or a C-like language such as C++, Python,
-        Java
-      - `F` if data is written by a Fortran code
-
   - `axisLabels`
     - type: 1-dimensional array containing N *(string)*
             elements, where N is the number of dimensions in the simulation
-    - description: ordering of the labels for the `geometry` of the mesh
-    - advice to implementors: in the ordering of variation for the indexes for
-                              matrices as defined by the index-operator
-                              (`[...][...]`) of the writing code
-    - advice to implementors: on read, query the record's `dataOrder` to get the
-                              information if you need to invert the access to
-                              `axisLabels` (and other attributes that use the
-                              same definition)
+    - description: this attribute assigns human-readible labels for the
+                   indices `i`, `j`, `k`, etc. denoting the axes of a mesh
+                   `A_{i,j,k}`
+    - advice to implementors: dimensions shall be ordered from slowest to
+                              fastest varying index when accessing the mesh
+                              contiguously (as 1D flattened logical memory)
+    - advice to implementors: if you access a ND array in C-like languages,
+                              a matrix `A[i,j,k]` will have its first index
+                              as the slowest varying index (e.g. `i`);
+    -                         if you access a ND array Fortran-like,
+                              a matrix `A(i,j,k)` will have its last index
+                              as the slowest varying index (e.g. `k`);
     - examples:
-      - 3D `cartesian` C-style `A[z,y,x]` write: `("z", "y", "x")` and `dataOrder='C'`
-      - 2D `cartesian` C-style `A[y,x]` write: `("y", "x")` and `dataOrder='C'`
-      - 2D `cartesian` Fortran-style `A[x,y]` write: `("x", "y")` and `dataOrder='F'`
-      - `thetaMode` Fortran-style `A[r,z]` write: `("r", "z")` and `dataOrder='F'`
+      - 3D `cartesian` mesh accessed in C-like as `A[z,y,x]` will have `z` as
+        its slowest varying index name and `axisLabels`: `("z", "y", "x")`
+      - 3D `cartesian` mesh accessed in C-like as `A[x,y,z]` will have `x` as
+        its slowest varying index name and `axisLabels`: `("x", "y", "z")`
+      - 2D `cartesian` mesh accessed in Fortran-like as `A(x,y)` will have `y` as
+        its slowest varying index name and `axisLabels`: `("y", "x")`
+      - `thetaMode` accessed Fortran-like `A(r,z)`, `axisLabels`: `("z", "r")`
 
   - `gridSpacing`
     - type: 1-dimensional array containing N *(floatX)*


### PR DESCRIPTION
The data order for indices arises naturally from its flattened memory layout.
This also holds true for logical access to the data.

This affects the *base standard* attributes:
- `axisLabels`
- `gridSpacing`
- `gridGlobalOffset`
- `shape` of constant record components

and the *ED-PIC* extension attributes:
- `fieldBoundary`
- `particleBoundary`

*Implements issues:* #125 and #129

## Description

`dataOrder` is superfluous.

By defining 1D-flattened dimensions like `axisLabel` are ordered by slowest to fastest varying index one can omit `dataOrder`. Slowest to fastest varying index here only means the logical flattened memory layout that one assumes for this data format.

This is possible since one does not care *how* data was written but just about *how to label/name indices* when reading data. E.g., one would increase from fastest to slowest dimension for all flattened descriptions over dimensions to read data efficiently without seeking.

*Let's have a C-like to Fortran-like example*

A C-matrix `A[i,j,k]` is written with `i` index standing for `"x"`, `j` for `"y"` and `k` for `"z"`. The associated `axisLabels` is in the index order k-j-i (slowest is first) which is `("x", "y", "z")`.

A Fortran-reader reads this matrix as `M(a,b,c)` with the index data order a-b-c (`c` is varies slowest). The `axisLabels` attribute reads `("x", "y", "z")`. So one will assign the fastest varying index `c` the label `"z"` , `b` the label `"y"` and the fastest varying index `a` an `"x"`. Index order and index label/name conserved - hurray! :sparkles: 

## Affected Components

- `base`
- `EXT: ED-PIC`

## Logic Changes

Before one had to to write the access-index order of the writing code. Now one writes the labels in the order "slowest-to-fastest varying index".

This does not change C-style, but Fortran-style access.

## Writer Changes

*How does this change affect data writers?*

Yes, Fortran-style writers need to invert their order now since the fastest varying index is the last.
C-style writers (C/C++/Python/Java/...) can just omit the `dataOrder` attribute now.

*Unaffected besides the now removed attribute:*

- `PIConGPU` (C++): https://github.com/ComputationalRadiationPhysics/picongpu/...
- `Warp` (Python-Writer): ...
- `FBPIC` (Python): ...
- `Smilei` (C++): https://github.com/SmileiPIC/Smilei
- `SIMEX Platform` (Python): https://github.com/eucall-software/simex_platform
- `openPMD-api` (C++): https://github.com/openPMD/openPMD-api/...

*Does this pull request change the interpretation of existing data writers?*

Fortran/Matlab/R/Julia codes: ...

## Reader Changes

*How does this change affect data readers?*

Yes, *all readers* can now just label/name flattened dimension accesses to e.g. labels of indices in the order "slowest-to-fastest index".

*What would a reader need to change? Link implementation examples!*

- [x] `openPMD-validator`: https://github.com/openPMD/openPMD-validator/pull/42
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `postpic`: https://github.com/skuschel/postpic
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `openPMD-api`: https://github.com/openPMD/openPMD-api/...

## Data Converter

Mesh records that declare `dataOrder='F'` need to invert the attributes mentioned above.

The unused `dataOrder` attribute should be removed as well.

- [x] https://github.com/openPMD/openPMD-updater/pull/4
