### PR TITLE
Make "time", "dt", "timeOffset" and "timeUnitSI" optional

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -233,9 +233,10 @@ Required Attributes for the `basePath`
 --------------------------------------
 
 In addition to holding information about the iteration, each series of
-files  (`fileBased`) or series of groups (`groupBased`) should have
-attributes that describe the current time and the last
-time step.
+files  (`fileBased`) or series of groups (`groupBased`) can have
+attributes that describe the current time and the last time step. (In the
+case where each iteration corresponds to a different time.) Thus, the 
+following attributes are *optional*:
 
  - `time`
    - type: *(floatX)*
@@ -661,6 +662,7 @@ Reminder: for scalar records the `record` itself is also the `component`.
 
   - `timeOffset`
     - type: *(floatX)*
+    - scope: *optional* (only used if `time` and `dt` are used)
     - description: the offset between the time at which this record is
                    defined and the `time` attribute of the `basePath` level.
                    This should be written in the same unit system as `time`


### PR DESCRIPTION
This makes the attributes "time", "dt", "timeOffset" and "timeUnitSI" optional.

*Implements issue:* #161

## Description

*As detailed description as possible.*

*What is introduced, removed or renamed and why?*
*What is made required, recommended, optional?*
*What concept stands behind this change?*

*Please also add an example.*

## Affected Components

- `base`

## Logic Changes

*Which logic changes are conceptually introduced?*

@RemiLehe please describe how a reader should handle time now. What if only few of the attributes are present? What if a mesh is read that has a *temporal* axis? #193 Or a particle record with `unitDimension` time? What are defaults in such a case and what quantities are additive?

## Writer Changes

The above attributes are now optional

- [ ] `openPMD-api`: https://github.com/openPMD/openPMD-api/...

## Reader Changes

Readers cannot explicitly assume that these attributes are present.

- [ ] `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
- [ ] `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- [ ] `yt`: https://github.com/yt-project/yt/...
- [ ] `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- [ ] `openPMD-api` (upcoming): https://github.com/openPMD/openPMD-api/...
- [ ] `XDMF` (upcoming): https://github.com/openPMD/openPMD-converter/...

## Data Updater

Not needed.