### PR TITLE
Move Particle Boundaries

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -82,35 +82,6 @@ The individual requirement is given in `scope`.
     - description: additional scheme and parameters specification for
                    the boundary conditions
 
-  - `particleBoundary`
-    - type: array of *(string)* of length 2 `N`
-    - scope: *required*
-    - description: boundary conditions in each direction (in the above, `N` is
-                   the dimensionality of the field mesh)
-                   The strings are stored in the following order:
-
-      - boundary at the *lower* end of the *first* axis as in `axisLabels`
-      - boundary at the *upper* end of the *first* axis as in `axisLabels`
-      - boundary at the *lower* end of the *second* axis as in `axisLabels`
-      - boundary at the *upper* end of the *second* axis as in `axisLabels`
-      - ...
-      - boundary at the *upper* end of the last axis as in `axisLabels`
-    - allowed values:
-      - `periodic`
-      - `absorbing`
-      - `reflecting`
-      - `reinjecting` (optionally add scheme specification - such as
-        "thermal, T=1keV" - in the `particleBoundaryParameters` string)
-      - `other`
-    - note: currently all particles must have the same boundary condition,
-            might become a particle attribute in the future
-
-  - `particleBoundaryParameters`
-    - type: array of *(string)* of length 2 `N`
-    - scope: *required* if `particleBoundary` is `other`, *optional* otherwise
-    - description: additional scheme and parameters specification for the
-                   boundary conditions
-
   - `currentSmoothing`
     - type: *(string)*
     - scope: *required*
@@ -258,6 +229,35 @@ The individual requirement is given in `scope`.
     - scope: *optional*
     - description: further parameters for current deposition schemes;
                    reserved for future use
+
+  - `particleBoundary`
+    - type: array of *(string)* of length 2 `N`
+    - scope: *required*
+    - description: boundary conditions in each direction (in the above, `N` is
+                   the dimensionality of the field mesh)
+                   The strings are stored in the following order:
+
+      - boundary at the *lower* end of the *first* axis as in `axisLabels`
+      - boundary at the *upper* end of the *first* axis as in `axisLabels`
+      - boundary at the *lower* end of the *second* axis as in `axisLabels`
+      - boundary at the *upper* end of the *second* axis as in `axisLabels`
+      - ...
+      - boundary at the *upper* end of the last axis as in `axisLabels`
+    - allowed values:
+      - `periodic`
+      - `absorbing`
+      - `reflecting`
+      - `reinjecting` (optionally add scheme specification - such as
+        "thermal, T=1keV" - in the `particleBoundaryParameters` string)
+      - `other`
+    - note: currently all particles must have the same boundary condition,
+            might become a particle attribute in the future
+
+  - `particleBoundaryParameters`
+    - type: array of *(string)* of length 2 `N`
+    - scope: *required* if `particleBoundary` is `other`, *optional* otherwise
+    - description: additional scheme and parameters specification for the
+                   boundary conditions
 
   - `particlePush`
     - type: *(string)*


### PR DESCRIPTION
As mentioned in #105, different particles may have different boundary condition. This PR fixes the issue making the particle boundary a particle species group attribute.

*Implements issue:* #105

## Description

Previously, the `particleBoundary` attribute was stored on `meshesPath`. We now store it for each particle species on the particle species group.

## Affected Components

- `EXT: ED-PIC`

## Logic Changes

*Which logic changes are conceptually introduced?*

## Writer Changes

*How does this change affect data writers?*
*What would a writer need to change?*
*Does this pull request change the interpretation of existing data writers?*

## Reader Changes

*How does this change affect data readers?*

*What would a reader need to change? Link implementation examples!*

- [x] `openPMD-validator`: https://github.com/openPMD/openPMD-validator/pull/50
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `openPMD-api` (upcoming): https://github.com/openPMD/openPMD-api/...
- `XDMF` (upcoming): https://github.com/openPMD/openPMD-converter/...

## Data Updater

*How does this affect already existing files with previous versions of the standard?*
*Is this change possible to be expressed in a way, that an automated tool can update the file?*
*Link code/pull requests that implement the upgrade logic!*

- [x] https://github.com/openPMD/openPMD-updater/pull/5

