### PR TITLE
Update Authors: Chris & Affil.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,13 +1,13 @@
 # List of Authors of the Standard
 
-### Original Design (2014-2015)
+### Original Design (2014-2015) and Lead Author (2014-2018)
 
 - Axel Huebl (HZDR, TU Dresden, a.huebl@hzdr.de)
 
-*Acknowledgements:* the design of this standard is based on the experiences
-                    we gained in the last years implementing efficient,
-                    parallel I/O in several PIC codes, but most recently
-                    in PIConGPU (picongpu.hzdr.de).
+*Acknowledgements:* the original design of this standard is based on the
+                    experiences we gained in the last years implementing
+                    efficient, parallel I/O in several PIC codes, but most
+                    recently in PIConGPU (picongpu.hzdr.de).
                     Special thanks goes to Felix Schmitt (TU Dresden)
                     and Rene Widera (HZDR).
 
@@ -17,13 +17,29 @@
 - Remi Lehe (LBNL)
 - Jean-Luc Vay (LBNL)
 - David P. Grote (LLNL)
-- Ivo Sbalzarini (TU Dresden, MPI-CBG)
-- Stephan Kuschel (IOQ Jena)
+- Ivo F. Sbalzarini (TU Dresden, MPI-CBG)
+- Stephan Kuschel (IOQ Jena, now SLAC)
 - Michael Bussmann (HZDR)
 
 
-### Reviewers and Substantive Contributions in Later Versions
+### Reviewers and Substantive Contributions in openPMD 2.0 (2017-2018)
 
-- David Sagan (Cornell University)
+Above authors and:
+
+- David Sagan (Cornell)
+- Christopher Mayes (SLAC)
 - Frédéric Pérez (LULI)
 - Fabian Koller (HZDR)
+
+
+### Affiliations
+
+- HZDR: Helmholtz-Zentrum Dresden - Rossendorf, Dresden, Germany
+- TU Dresden: Technical University Dresden, Dresden, Germany
+- LBNL: Lawrence Berkeley National Lab, Berkeley (CA), United States of America
+- LLNL: Lawrence Livermore National Laboratory, Livermore (CA), United States of America
+- MPI-CBG: Max Planck Institute of Molecular Cell Biology and Genetics, Dresden, Germany
+- IOQ Jena: Institut für Optik und Quantenelektronik, Jena, Germany
+- SLAC: SLAC National Accelerator Laboratory, Menlo Park (CA), United States of America
+- Cornell: Cornell University, Ithaca (NY), United States of America
+- LULI: Laboratoire pour l'Utilisation des Lasers Intenses, Paris, France


### PR DESCRIPTION
Add Christopher as the co-author of the beam physics extension `EXT:BeamPhysics` in #183.

Updated Stephan's affiliation. Add Ivo's middle name he uses in scientific work.