### PR TITLE
thetaMode Geometry: Fix Description (Sign)

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -349,7 +349,7 @@ meshes):
                      three-dimensional record where the last axis corresponds
                      to the `z` direction, the second axis correspond to the
                      `r` direction and where the first axis corresponds to
-                     the azimuthal mode. (This last axis has length `2m+1`,
+                     the azimuthal mode. (This last axis has length `2m-1`,
                      where `m` is the number of modes used. By convention,
                      this first stores the real part of the mode `0`, then
                      the real part of the mode `1`, then the imaginary part


### PR DESCRIPTION
Fix a little typo in the description of `thetaMode` geometry.

## Description

@RemiLehe and I found a typo during the implementation of RZ mode in WarpX.
Since the first mode is real-only, the number of components in `m` modes is `2m-1` (imaginary & real for every mode besides the first).

## Affected Components

- `base`

## Logic Changes

No changes.

## Writer Changes

No changes.

## Reader Changes

No changes.

## Data Converter

No changes needed.