### PR TITLE
Base: Link BeamPhysics & Wavefront Extension

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -748,10 +748,14 @@ the standard, using multiple extensions at the same time is discouraged.
 Up to now, the following domain-specific naming conventions for have been
 defined:
 
+- **BeamPhysics**: particle beams, photons, and external fields for accelerator physics,
+  see [EXT_BeamPhysics.md](EXT_BeamPhysics.md).
 - **ED-PIC**: electro-dynamic/static particle-in-cell codes,
   see [EXT_ED-PIC.md](EXT_ED-PIC.md).
 - **SpeciesType**: naming lists for particle species,
   see [EXT_SpeciesType.md](EXT_SpeciesType.md).
+- **WAVEFRONT**: fields for coherent wavefront propagation codes,
+  see [EXT_WAVEFRONT.md](EXT_WAVEFRONT.md).
 
 Extensions to similar domains such as fluid, finite-element or
 molecular-dynamics simulations, CCD images or other particle and/or mesh-based


### PR DESCRIPTION
## Description

Link newly added extensions in the base standard.

See #230 #150 

## Affected Components

- `base`
- EXT: `BeamPhysics`
- EXT: `WAVEFRONT`

## Logic Changes

None.

## Writer Changes

None.

## Reader Changes

None.

## Data Updater

None.
