### PR TITLE
EXT: ParticleWeighting

### DIFF
--- a/EXT_ED-PIC.md
+++ b/EXT_ED-PIC.md
@@ -18,6 +18,14 @@ simulations) that will allow to restart the checkpoints of one PIC code with
 an other.
 
 
+Dependencies
+------------
+
+This extension depends on the [ParticleWeighting](EXT_ParticleWeighting.md) extension.
+
+It is sufficient for writers to only declare the `ED-PIC` extension to express this dependency. Thus, reading implementations need to be aware that a declared `ED-PIC` extension implies `ParticleWeighting` is also applied.
+
+
 Mesh Based Records (Fields)
 ---------------------------
 
@@ -322,58 +330,7 @@ The individual requirement is given in `scope`.
 
 ### Additional Attributes for each Particle `Record`
 
-The following additional attributes for `particle record`s are defined in this
-extension. The individual requirement is given in `scope`.
-
-When using macroparticles (see below for the definition of the
-macroparticle `weighting`), there is an ambiguity regarding whether the
-particle quantity that is written (e.g. energy, momentum) is that of
-the full macroparticle, or that of the underlying individual
-particle. Therefore, this extension requires the two following attributes:
-
-- `macroWeighted`
-  - type: *(uint32)*
-  - scope: *required*
-  - description: indicates whether this quantity is written for the underlying
-                 particle (`macroWeighted = 0`) or for the full macroparticle
-                 (`macroWeighted = 1`)
-  - example: Let us assume that a user writes the `charge` attribute of a
-             macroparticle that represents 100 electrons. If this user chooses
-             to write -1.6e-19 (charge of one individual electron) then
-             `macroWeighted` must be 0. If the user writes -1.6e-17 (total
-             charge of 100 electrons), then macroweighted must be 1
-
-- `weightingPower`
-  - type: *(float64 / REAL8)*
-  - scope: *required*
-  - description: indicates with which power of `weighting` (see below)
-                 the quantity should be multiplied, in order to go from the
-                 individual-particle representation to the full-macroparticle
-                 representation
-  - example: Let us consider a macroparticle that represents 100 electrons.
-             In this case, `weighting` is w=100 and the charge of each
-             underlying individual particle is q=-1.6e-19. Then the charge Q of
-             the full macroparticle is given by: Q=q w^1 and therefore
-             `weightingPower` must be 1.
-  - advice to implementors: reading example (with h5py) and extracting charge
-                            of the macroparticles in Python. When not
-                            absolutely necessary, reading the additional
-                            `weighting` record can be avoided for performance
-                            reasons like this:
-```python
-f = h5py.File('example.h5')
-species = f["<path_to_species_group>"]
-q = species["charge"][:]
-# `default` handles the case where conversion to SI is not provided
-u_si = q.attrs.get("unitSI", default=1.)
-p = q.attrs["weightingPower"]
-if q.attrs["macroWeighted"] == 0 and p != 0:
-    w = species["weighting"][:]
-    q_macro = u_si * q * w**p
-else :
-    # No need to read the weighting from disk
-    q_macro = u_si * q
-```
+Note the definitions of the attributes `macroWeighted` and `weightingPower` in the [ParticleWeighting](EXT_ParticleWeighting.md) extension.
 
 ### Namings for `Records` per Particle Species
 
@@ -402,12 +359,7 @@ should be used to push the particle.
                               (mass)
 
   - `weighting`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: the number of underlying individual particles that
-                   the macroparticles represent
-    - advice to implementors: must have `weightingPower = 1`,
-                              `macroWeighted = 1`, `unitSI = 1` and
-                              `unitDimension == (0., ..., 0.)`
+    - see the [ParticleWeighting](EXT_ParticleWeighting.md) extension
 
   - `momentum/` + components such as `x`, `y` and `z`
     - type: each component in *(floatX)* or *(intX)* or *(uintX)*

--- a/EXT_ParticleWeighting.md
+++ b/EXT_ParticleWeighting.md
@@ -1,0 +1,85 @@
+Conventions for Weighted Particles
+==================================
+
+openPMD extension name: `ParticleWeighting`
+
+
+Introduction
+------------
+
+In the description of discrete particle distributions, it is common to represent a collection of particles with fewer, representative particles. A typical approach is to assign a weight to each particle, which scales all physical properties it represents accordingly.
+
+
+Particle Records
+----------------
+
+Weighted particles are also known as macroparticles.
+
+### Additional Attributes for each Particle `Record`
+
+The following additional attributes for `particle record`s are defined in this
+extension. The individual requirement is given in `scope`.
+
+When using macroparticles (see below for the definition of the
+macroparticle `weighting`), there is an ambiguity regarding whether the
+particle quantity that is written (e.g. energy, momentum) is that of
+the full macroparticle, or that of the underlying individual
+particle. Therefore, this extension requires the two following attributes:
+
+- `macroWeighted`
+  - type: *(uint32)*
+  - scope: *required*
+  - description: indicates whether this quantity is written for the underlying
+                 particle (`macroWeighted = 0`) or for the full macroparticle
+                 (`macroWeighted = 1`)
+  - example: Let us assume that a user writes the `charge` attribute of a
+             macroparticle that represents 100 electrons. If this user chooses
+             to write -1.6e-19 (charge of one individual electron) then
+             `macroWeighted` must be 0. If the user writes -1.6e-17 (total
+             charge of 100 electrons), then macroweighted must be 1
+
+- `weightingPower`
+  - type: *(float64 / REAL8)*
+  - scope: *required*
+  - description: indicates with which power of `weighting` (see below)
+                 the quantity should be multiplied, in order to go from the
+                 individual-particle representation to the full-macroparticle
+                 representation
+  - example: Let us consider a macroparticle that represents 100 electrons.
+             In this case, `weighting` is w=100 and the charge of each
+             underlying individual particle is q=-1.6e-19. Then the charge Q of
+             the full macroparticle is given by: Q=q w^1 and therefore
+             `weightingPower` must be 1.
+  - advice to implementors: reading example (with h5py) and extracting charge
+                            of the macroparticles in Python. When not
+                            absolutely necessary, reading the additional
+                            `weighting` record can be avoided for performance
+                            reasons like this:
+```python
+f = h5py.File('example.h5')
+species = f["<path_to_species_group>"]
+q = species["charge"][:]
+# `default` handles the case where conversion to SI is not provided
+u_si = q.attrs.get("unitSI", default=1.)
+p = q.attrs["weightingPower"]
+if q.attrs["macroWeighted"] == 0 and p != 0:
+    w = species["weighting"][:]
+    q_macro = u_si * q * w**p
+else :
+    # No need to read the weighting from disk
+    q_macro = u_si * q
+```
+
+### Namings for `Records` per Particle Species
+
+When added as records to a particle output, the following naming conventions
+shall be used.
+
+  - `weighting`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: the number of underlying individual particles that
+                   the macroparticles represent
+    - advice to implementors: must have `weightingPower = 1`,
+                              `macroWeighted = 1`, `unitSI = 1` and
+                              `unitDimension == (0., ..., 0.)`
+

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -750,6 +750,8 @@ defined:
 
 - **ED-PIC**: electro-dynamic/static particle-in-cell codes,
   see [EXT_ED-PIC.md](EXT_ED-PIC.md).
+- **ParticleWeighting**: conventions for macroparticles,
+  see [EXT_ParticleWeighting.md](EXT_ParticleWeighting.md).
 - **SpeciesType**: naming lists for particle species,
   see [EXT_SpeciesType.md](EXT_SpeciesType.md).
 


### PR DESCRIPTION
## Description

This moves parts of the ED-PIC extension into its own extension for reuse in other domains.
    
We already conditionally honor weightings in tools like openPMD-viewer and its not specific to PIC simulations.

*Implements issue:* #237

## Affected Components

- [x] `base`
- [x] EXT:  `ED-PIC`
- [x] EXT:  `ParticleWeighting`

## Logic Changes

The definition of the `weighting` record and the `macroWeighted` and `weightingPower` attributes is moved from ED-PIC to its own extension.
ED-PIC now depends on the new extension, so there is no change to the ED-PIC extension on a logical level.

## Writer Changes

- [x] `openPMD-api`: https://github.com/openPMD/openPMD-api: not affected, because added by users manually

## Reader Changes

- [ ] `openPMD-validator`: https://github.com/openPMD/openPMD-validator can be generalized to check weighting if either `ED-PIC` or `ParticleWeighting` (or both) are declared
- [x] `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer already applies weighting conditionally if found; can be generalized to check the extension first
- [x] `yt`: https://github.com/yt-project/yt not affected
- [x] `VisIt`: https://github.com/openPMD/openPMD-visit-plugin not affected
- [x] `converter`: https://github.com/openPMD/openPMD-converter not affected
- [x] `openPMD-api`: https://github.com/openPMD/openPMD-api not affected, because read by users manually

## Data Updater

- [x] https://github.com/openPMD/openPMD-updater no update needed