### PR TITLE
Authors: 2021

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,8 +1,8 @@
 # List of Authors of the Standard
 
-### Original Design (2014-2015) and Lead Author (2014-2020)
+### Original Design (2014-2015) and Lead Author (2014-2021)
 
-- Axel Huebl (HZDR, TU Dresden, a.huebl@hzdr.de)
+- Axel Huebl (LBNL, previously HZDR, axelhuebl@lbl.gov)
 
 *Acknowledgements:* the original design of this standard is based on the
                     experiences we gained in the last years implementing
@@ -18,11 +18,11 @@
 - Jean-Luc Vay (LBNL)
 - David P. Grote (LLNL)
 - Ivo F. Sbalzarini (TU Dresden, MPI-CBG)
-- Stephan Kuschel (IOQ Jena, now SLAC)
-- Michael Bussmann (HZDR)
+- Stephan Kuschel (IOQ Jena, now Uni Hamburg)
+- Michael Bussmann (CASUS, HZDR)
 
 
-### Reviewers and Substantive Contributions in openPMD 2.0 (2017-2020)
+### Reviewers and Substantive Contributions in openPMD 2.0 (2017-2021)
 
 Above authors and:
 
@@ -30,6 +30,10 @@ Above authors and:
 - Christopher Mayes (SLAC)
 - Frédéric Pérez (LULI)
 - Fabian Koller (HZDR)
+- Franz Poeschel (CASUS)
+- Carsten Fortmann-Grote (MPI-EvolBio)
+- Ángel Ferran Pousa (DESY)
+- Juncheng E (EU XFEL)
 
 
 ### Affiliations
@@ -40,6 +44,10 @@ Above authors and:
 - LLNL: Lawrence Livermore National Laboratory, Livermore (CA), United States of America
 - MPI-CBG: Max Planck Institute of Molecular Cell Biology and Genetics, Dresden, Germany
 - IOQ Jena: Institut für Optik und Quantenelektronik, Jena, Germany
-- SLAC: SLAC National Accelerator Laboratory, Menlo Park (CA), United States of America
+- Uni Hamburg: University Hamburg, Hamburg, Germany
 - Cornell: Cornell University, Ithaca (NY), United States of America
 - LULI: Laboratoire pour l'Utilisation des Lasers Intenses, Paris, France
+- CASUS: Center for Advanced Systems Understanding, Goerlitz, Germany
+- MPI-EvolBio: Max-Planck-Institute for Evolutionary Biology, Ploen, Germany
+- DESY: German Electron Synchrotron DESY, Hamburg, Germany
+- EU XFEL: European XFEL GmbH, Schenefeld, Germany

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,7 +31,7 @@ Above authors and:
 - Frédéric Pérez (LULI)
 - Fabian Koller (HZDR)
 - Franz Poeschel (CASUS)
-- Carsten Fortmann-Grote (MPI-EvolBio)
+- Carsten Fortmann-Grote (EU XFEL, MPI-EvolBio)
 - Ángel Ferran Pousa (DESY)
 - Juncheng E (EU XFEL)
 


### PR DESCRIPTION
Update co-authors  to reflect updates in 2021.

- @ax3l: continued contribution & lead under new affiliation
- @skuschel: new affiliation note, contributions all under old affiliation
- @bussmann: new co-affiliation
- @franzpoeschel: introduced conventions for JSON and ADIOS2; further conventions with Axel to data staging/streaming coming #244 
- @AngelFP: contributions to generalizations; improvements for needs of GUIs #237 #238 #239
- @CFGrote: contributed wavefront extension #230
- @JunCEEE: MD simulation extension #218

Thank you all again for your great contributions to openPMD! :rocket: :sparkles: 