### PR TITLE
Ext: Wavefront

### DIFF
--- a/EXT_Wavefront.md
+++ b/EXT_Wavefront.md
@@ -1,7 +1,7 @@
 Domain-Specific Naming Conventions for Coherent Wavefront Propagation Codes
 ===========================================================================
 
-openPMD extension name: `WAVEFRONT`
+openPMD extension name: `Wavefront`
 
 
 Introduction

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -758,8 +758,8 @@ defined:
   see [EXT_ParticleWeighting.md](EXT_ParticleWeighting.md).
 - **SpeciesType**: naming lists for particle species,
   see [EXT_SpeciesType.md](EXT_SpeciesType.md).
-- **WAVEFRONT**: fields for coherent wavefront propagation codes,
-  see [EXT_WAVEFRONT.md](EXT_WAVEFRONT.md).
+- **Wavefront**: fields for coherent wavefront propagation codes,
+  see [EXT_Wavefront.md](EXT_Wavefront.md).
 
 Extensions to similar domains such as fluid, finite-element or
 molecular-dynamics simulations, CCD images or other particle and/or mesh-based


### PR DESCRIPTION
## Description

Rename to common naming scheme for extensions.

## Affected Components

- `base`
- `EXT-Wavefront`

## Logic Changes

The identifier of the extension, as planned for openPMD 2.0, is changed.

## Writer Changes

need to change the identifier string

## Reader Changes

need to change the identifier string

## Data Converter

not yet released and only merged since #230 
