### PR TITLE
Replace operatorname with mathrm in LateX MD rendering

### DIFF
--- a/EXT_LaserEnvelope.md
+++ b/EXT_LaserEnvelope.md
@@ -18,12 +18,12 @@ The laser pulse is represented as a single complex field $\mathcal{E}$, describi
 
 ```math
    \begin{aligned}
-   E_x &= \operatorname{Re}\left( \mathcal{E} e^{-i\omega_0t}p_x\right)\\
-   E_y &= \operatorname{Re}\left( \mathcal{E} e^{-i\omega_0t}p_y\right)\\
+   E_x &= \mathrm{Re}\left( \mathcal{E} e^{-i\omega_0t}p_x\right)\\
+   E_y &= \mathrm{Re}\left( \mathcal{E} e^{-i\omega_0t}p_y\right)\\
 \end{aligned}
 ```
 
-where $\operatorname{Re}$ stands for real part,  $E_x$ (resp. $E_y$) is the laser electric field in the x (resp. y) direction, $\mathcal{E}$ is the complex laser envelope described in the standard, $\omega_0 = 2\pi c/\lambda_0$ is the angular frequency defined from the laser wavelength $\lambda_0$ and $(p_x,p_y)$ is the (complex and normalized) polarization vector. The polarization state (linear, circular, elliptical) is controlled by the phase of the polarization vector. For instance, if $arg(p_x) = arg(p_y)$, the polarization is linear. If $arg(p_x) = arg(p_y) + \pi/2$, the polarization is circular.
+where $\mathrm{Re}$ stands for real part,  $E_x$ (resp. $E_y$) is the laser electric field in the x (resp. y) direction, $\mathcal{E}$ is the complex laser envelope described in the standard, $\omega_0 = 2\pi c/\lambda_0$ is the angular frequency defined from the laser wavelength $\lambda_0$ and $(p_x,p_y)$ is the (complex and normalized) polarization vector. The polarization state (linear, circular, elliptical) is controlled by the phase of the polarization vector. For instance, if $arg(p_x) = arg(p_y)$, the polarization is linear. If $arg(p_x) = arg(p_y) + \pi/2$, the polarization is circular.
 
 When added to an output, the following naming conventions shall be used for complex electric field `mesh records`.
 


### PR DESCRIPTION
This fixes rendering markdown issues in https://github.com/openPMD/openPMD-standard/blob/upcoming-2.0.0/EXT_LaserEnvelope.md.

Follow-up to #271

## Affected Components

- `EXT_LaserEnvelope.md`