### PR TITLE
Markdown `EXT:LaserEnvelope` LaTeX Fix

### DIFF
--- a/EXT_LaserEnvelope.md
+++ b/EXT_LaserEnvelope.md
@@ -18,12 +18,12 @@ The laser pulse is represented as a single complex field $\mathcal{E}$, describi
 
 ```math
    \begin{aligned}
-   E_x &= \operatorname{Re}\left( \mathcal{E} e^{-i\omega_0t}p_x\right)\\
-   E_y &= \operatorname{Re}\left( \mathcal{E} e^{-i\omega_0t}p_y\right)\\
+   E_x &= \mathrm{Re}\left( \mathcal{E} e^{-i\omega_0t}p_x\right)\\
+   E_y &= \mathrm{Re}\left( \mathcal{E} e^{-i\omega_0t}p_y\right)\\
 \end{aligned}
 ```
 
-where $\operatorname{Re}$ stands for real part,  $E_x$ (resp. $E_y$) is the laser electric field in the x (resp. y) direction, $\mathcal{E}$ is the complex laser envelope described in the standard, $\omega_0 = 2\pi c/\lambda_0$ is the angular frequency defined from the laser wavelength $\lambda_0$ and $(p_x,p_y)$ is the (complex and normalized) polarization vector. The polarization state (linear, circular, elliptical) is controlled by the phase of the polarization vector. For instance, if $arg(p_x) = arg(p_y)$, the polarization is linear. If $arg(p_x) = arg(p_y) + \pi/2$, the polarization is circular.
+where $\mathrm{Re}$ stands for real part,  $E_x$ (resp. $E_y$) is the laser electric field in the x (resp. y) direction, $\mathcal{E}$ is the complex laser envelope described in the standard, $\omega_0 = 2\pi c/\lambda_0$ is the angular frequency defined from the laser wavelength $\lambda_0$ and $(p_x,p_y)$ is the (complex and normalized) polarization vector. The polarization state (linear, circular, elliptical) is controlled by the phase of the polarization vector. For instance, if $arg(p_x) = arg(p_y)$, the polarization is linear. If $arg(p_x) = arg(p_y) + \pi/2$, the polarization is circular.
 
 When added to an output, the following naming conventions shall be used for complex electric field `mesh records`.
 


### PR DESCRIPTION
## Description

Per Support:
Thanks for reaching out to GitHub Support about problems rendering LaTeX that uses the \operatorname macro. I see that we just removed support for some potentially harmful LaTeX macros that allow for either overriding other macros or operators, or would potentially allow for invisible text. Among these is \operatorname.

Same as https://github.com/LASY-org/lasy/pull/134

Follow-up to #271

## Affected Components

- `EXT-LaserEnvelope`

## Logic Changes

None.

## Writer Changes

None.

## Reader Changes

None.

## Data Converter

None.