### PR TITLE
Authors: Maxence Thévenet

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,6 +34,7 @@ Above authors and:
 - Carsten Fortmann-Grote (EU XFEL, MPI-EvolBio)
 - Ángel Ferran Pousa (DESY)
 - Juncheng E (EU XFEL)
+- Maxence Thévenet (DESY)
 
 
 ### Affiliations


### PR DESCRIPTION
Add @MaxThevenet to the openPMD co-authors for 2.0+.

He authored the `LaserEnvelope` extension in #271 ff.