### PR TITLE
Lists of Iteration, Mesh and Particle Pathes

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -124,72 +124,51 @@ The following attributes are *optional* in each each file's *root* group
 
   - `meshesPath`
     - type: 1-dimensional array containing N *(string)*
-    - description: List of regular expressions (regex) that specify the location
-                   of mesh records *relative* from the `basePath`.
-                   Let the path to a mesh record be denoted by
-                   `<pathToContainingGroup>/<containingGroupName>/<meshRecordName>`,
-                   relative to the `basePath` and starting
-                   with a leading slash `/`.
-                   The mesh can be specified in three different ways:
+    - description: List of globbing expressions that specify the location
+                   of mesh containers *relative* from the `basePath`.
+                   Mesh containers are openPMD groups that contain meshes.
+                   Each group in a mesh container is treated as a mesh; each dataset in a mesh container is treated as a (scalar) mesh.
+                   The entries in the `meshesPath` can be specified in two different ways:
 
-      1. **Full path to the group containing meshes**:
-        The `meshesPath` contains
-        `<pathToContainingGroup>/<containingGroupName>/`
-        This mode is recognized by both the leading and trailing
-        slash `/`.
-        Any group found in this group will be interpreted as a mesh record.
-      2. **Full path to the mesh itself**:
-        The `meshesPath` contains
-        `<pathToContainingGroup>/<containingGroupName>/<meshRecordName>`
-        This mode is recognized by a leading, but no trailing slash `/`.
-        This specific path will be interpreted as a mesh record.
-      3. **Shorthand notation: Name of groups that contain meshes**:
-        The `meshesPath` contains `<containingGroupName>/`.
-        This mode is recognized by no leading, but a trailing slash.
-        No further slashes than the trailing slash must be used.
-        Any group with the specified name will be treated as containing only
-        meshes.
+      1. **Full path to mesh container**:
+        An entry in the `meshesPath` that starts and ends with a slash `/`.
+        This can also be a globbing expression:
 
-    - Examples for the 3 different notations:
+        a. A single `%` expands to any legal group name.
+        b. A double `%%` expands to any legal path. Unlike a single `%`, its expansion may contain slashes. The full path may start with a double `%%` instead of the leading slash `/`.
 
-      1. `.*/meshes/` is equivalent to `meshes/` (see format 3).
+        As a regular expression: `(/|%%)[[:alnum:]_%/]+/`.
+
+      2. **Shorthand notation: Name of mesh containers**:
+        An entry in the `meshesPath` that ends with a slash `/` and contains no other slashes.
+        Any group with the specified name will be treated as a mesh container.
+        There is no globbing support.
+
+        As a regular expression: `[[:alnum:]_]+/`.
+
+    - Examples for the 2 different notations:
+
+      1. `%%/meshes/` is equivalent to `meshes/` (see format 3).
         Specifying `/meshes/` refers only to the `meshes` group found
         directly in the base path, e.g. in a group-based file:
 
           - `/data/0/meshes/E` will be recognized as a mesh,
           - but `/data/100/refinement_levels/2/meshes/E` will not.
 
-        In this example, `/refinement_levels/[[:num:]]+/meshes/` can be used
+        In this example, `/refinement_levels/%/meshes/` can be used
         to refer to the meshes found at different mesh refinement levels.
-      2. `/meshes/E` refers only to this particular mesh relative from the
-        `basePath`. E.g., in a group-based file:
 
-          - `/data/100/meshes/E` will be recognized as a mesh,
-          - but neither will `/data/50/meshes/B`,
-          - nor will `/data/0/refinement_levels/2/meshes/E`.
-
-      3. `meshes/`: Any group with name `meshes` contains only mesh records.
+      2. `meshes/`: Any group with name `meshes` contains only mesh records.
         In a group-based file, this will recognize the following paths
         as meshes:
 
           - `/data/0/meshes/E`
           - `/data/100/refinement_levels/2/meshes/E`
 
-    - Notes:
+    - Note:
 
-        A single regex is technically sufficient since regexes can express
-        multiple options. However, using a list improves legibility and can
-        help tooling interpret user intent better (e.g. if the first list
-        entry is `fields/`, then an implementation can choose to use that
-        name by default instead of `meshes/`).
-
-        The shorthand notation (format 3) corresponds with the openPMD 1.0
+        The shorthand notation (format 2) corresponds with the openPMD 1.0
         notation of meshes paths.
-
-        No specific dialect of regular expressions is specified, but the
-        `egrep` style is recommended.
-        @TODO: Should we use a recommendation? Should we encode the style
-        as an attribute?
 
   - `particlesPath`
     - type: 1-dimensional array containing N *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -172,51 +172,41 @@ The following attributes are *optional* in each each file's *root* group
 
   - `particlesPath`
     - type: 1-dimensional array containing N *(string)*
-    - description: List of regular expressions (regex) that specify the location
-                   of particle species *relative* from the `basePath`.
-                   Let the path to a particle species be denoted by
-                   `<pathToContainingGroup>/<containingGroupName>/<particleSpeciesName>`,
-                   relative to the `basePath` and starting
-                   with a leading slash `/`.
-                   The particle can be specified in three different ways:
+    - description: List of globbing expressions that specify the location
+                   of particle containers *relative* from the `basePath`.
+                   Particle containers are openPMD groups that contain (one or more) particle species.
+                   Each group in a particle container is treated as a particle species.
+                   The entries in the `particlesPath` can be specified in two different ways:
 
-      1. **Full path to the group containing particles**:
-        The `particlesPath` contains
-        `<pathToContainingGroup>/<containingGroupName>/`
-        This mode is recognized by both the leading and trailing
-        slash `/`.
-        Any group found in this group will be interpreted as a particle species.
-      2. **Full path to the particle species itself**:
-        The `particlesPath` contains
-        `<pathToContainingGroup>/<containingGroupName>/<particleSpeciesName>`
-        This mode is recognized by a leading, but no trailing slash `/`.
-        This specific path will be interpreted as a particle record.
-      3. **Shorthand notation: Name of groups that contain particles**:
-        The `particlesPath` contains `<containingGroupName>/`.
-        This mode is recognized by no leading, but a trailing slash.
-        No further slashes than the trailing slash must be used.
-        Any group with the specified name will be treated as containing only
-        particles.
+      1. **Full path to particle container**:
+        An entry in the `particlesPath` that starts and ends with a slash `/`.
+        This can also be a globbing expression:
 
-    - Examples for the 3 different notations:
+        a. A single `%` expands to any legal group name.
+        b. A double `%%` expands to any legal path. Unlike a single `%`, its expansion may contain slashes. The full path may start with a double `%%` instead of the leading slash `/`.
 
-      1. `.*/particles/` is equivalent to `particles/` (see format 3).
+        As a regular expression: `(/|%%)[[:alnum:]_%/]+/`.
+
+      2. **Shorthand notation: Name of mesh containers**:
+        An entry in the `particlesPath` that ends with a slash `/` and contains no other slashes.
+        Any group with the specified name will be treated as a particles container.
+        There is no globbing support.
+
+        As a regular expression: `[[:alnum:]_]+/`.
+
+    - Examples for the 2 different notations:
+
+      1. `%%/particles/` is equivalent to `particles/` (see format 2).
         Specifying `/particles/` refers only to the `particles` group found
         directly in the base path, e.g. in a group-based file:
 
           - `/data/0/particles/e` will be recognized as a particle species,
           - but `/data/100/generations/2/particles/e` will not.
 
-        In this example, `/generations/[[:num:]]+/particles/` can be used
+        In this example, `/generations/%/particles/` can be used
         to refer to the particles found at different particle generations.
-      2. `/particles/e` refers only to this particular particle species relative
-        from the `basePath`. E.g., in a group-based file:
 
-          - `/data/100/particles/e` will be recognized as a particle species,
-          - but neither will `/data/50/particles/i`,
-          - nor will `/data/0/generations/2/particles/e`.
-
-      3. `particles/`: Any group with name `particles` contains only
+      2. `particles/`: Any group with name `particles` contains only
         particle species.
         In a group-based file, this will recognize the following paths
         as particle species:
@@ -226,19 +216,8 @@ The following attributes are *optional* in each each file's *root* group
 
     - Notes:
 
-        A single regex is technically sufficient since regexes can express
-        multiple options. However, using a list improves legibility and can
-        help tooling interpret user intent better (e.g. if the first list
-        entry is `fields/`, then an implementation can choose to use that
-        name by default instead of `particles/`).
-
-        The shorthand notation (format 3) corresponds with the openPMD 1.0
+        The shorthand notation (format 2) corresponds with the openPMD 1.0
         notation of particles paths.
-
-        No specific dialect of regular expressions is specified, but the
-        `egrep` style is recommended.
-        @TODO: Should we use a recommendation? Should we encode the style
-        as an attribute?
 
 It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -123,12 +123,73 @@ The following attributes are *optional* in each each file's *root* group
 *required* to set them if one wants to store mesh and/or particle records.
 
   - `meshesPath`
-    - type: *(string)*
-    - description: path *relative* from the `basePath` to the mesh records
-    - example: `meshes/`
-    - note: if this attribute is missing, the file is interpreted as if it
-      contains *no mesh records*! If the attribute is set, the group behind
-      it *must* exist!
+    - type: 1-dimensional array containing N *(string)*
+    - description: List of regular expressions (regex) that specify the location
+                   of mesh records *relative* from the `basePath`.
+                   Let the path to a mesh record be denoted by
+                   `<pathToContainingGroup>/<containingGroupName>/<meshRecordName>`,
+                   relative to the `basePath` and starting
+                   with a leading slash `/`.
+                   The mesh can be specified in three different ways:
+
+      1. **Full path to the group containing meshes**:
+        The `meshesPath` contains
+        `<pathToContainingGroup>/<containingGroupName>/`
+        This mode is recognized by both the leading and trailing
+        slash `/`.
+        Any group found in this group will be interpreted as a mesh record.
+      2. **Full path to the mesh itself**:
+        The `meshesPath` contains
+        `<pathToContainingGroup>/<containingGroupName>/<meshRecordName>`
+        This mode is recognized by a leading, but no trailing slash `/`.
+        This specific path will be interpreted as a mesh record.
+      3. **Shorthand notation: Name of groups that contain meshes**:
+        The `meshesPath` contains `<containingGroupName>/`.
+        This mode is recognized by no leading, but a trailing slash.
+        No further slashes than the trailing slash must be used.
+        Any group with the specified name will be treated as containing only
+        meshes.
+
+    - Examples for the 3 different notations:
+
+      1. `.*/meshes/` is equivalent to `meshes/` (see format 3).
+        Specifying `/meshes/` refers only to the `meshes` group found
+        directly in the base path, e.g. in a group-based file:
+
+          - `/data/0/meshes/E` will be recognized as a mesh,
+          - but `/data/100/refinement_levels/2/meshes/E` will not.
+
+        In this example, `/refinement_levels/[[:num:]]+/meshes/` can be used
+        to refer to the meshes found at different mesh refinement levels.
+      2. `/meshes/E` refers only to this particular mesh relative from the
+        `basePath`. E.g., in a group-based file:
+
+          - `/data/100/meshes/E` will be recognized as a mesh,
+          - but neither will `/data/50/meshes/B`,
+          - nor will `/data/0/refinement_levels/2/meshes/E`.
+
+      3. `meshes/`: Any group with name `meshes` contains only mesh records.
+        In a group-based file, this will recognize the following paths
+        as meshes:
+
+          - `/data/0/meshes/E`
+          - `/data/100/refinement_levels/2/meshes/E`
+
+    - Notes:
+
+        A single regex is technically sufficient since regexes can express
+        multiple options. However, using a list improves legibility and can
+        help tooling interpret user intent better (e.g. if the first list
+        entry is `fields/`, then an implementation can choose to use that
+        name by default instead of `meshes/`).
+
+        The shorthand notation (format 3) corresponds with the openPMD 1.0
+        notation of meshes paths.
+
+        No specific dialect of regular expressions is specified, but the
+        `egrep` style is recommended.
+        @TODO: Should we use a recommendation? Should we encode the style
+        as an attribute?
 
   - `particlesPath`
     - type: *(string)*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -192,13 +192,74 @@ The following attributes are *optional* in each each file's *root* group
         as an attribute?
 
   - `particlesPath`
-    - type: *(string)*
-    - description: path *relative* from the `basePath` to the groups for each
-                   particle group and the records they include
-    - example: `particles/`
-    - note: if this attribute is missing, the file is interpreted as if it
-      contains *no particle records*! If the attribute is set, the group behind
-      it *must* exist!
+    - type: 1-dimensional array containing N *(string)*
+    - description: List of regular expressions (regex) that specify the location
+                   of particle species *relative* from the `basePath`.
+                   Let the path to a particle species be denoted by
+                   `<pathToContainingGroup>/<containingGroupName>/<particleSpeciesName>`,
+                   relative to the `basePath` and starting
+                   with a leading slash `/`.
+                   The particle can be specified in three different ways:
+
+      1. **Full path to the group containing particles**:
+        The `particlesPath` contains
+        `<pathToContainingGroup>/<containingGroupName>/`
+        This mode is recognized by both the leading and trailing
+        slash `/`.
+        Any group found in this group will be interpreted as a particle species.
+      2. **Full path to the particle species itself**:
+        The `particlesPath` contains
+        `<pathToContainingGroup>/<containingGroupName>/<particleSpeciesName>`
+        This mode is recognized by a leading, but no trailing slash `/`.
+        This specific path will be interpreted as a particle record.
+      3. **Shorthand notation: Name of groups that contain particles**:
+        The `particlesPath` contains `<containingGroupName>/`.
+        This mode is recognized by no leading, but a trailing slash.
+        No further slashes than the trailing slash must be used.
+        Any group with the specified name will be treated as containing only
+        particles.
+
+    - Examples for the 3 different notations:
+
+      1. `.*/particles/` is equivalent to `particles/` (see format 3).
+        Specifying `/particles/` refers only to the `particles` group found
+        directly in the base path, e.g. in a group-based file:
+
+          - `/data/0/particles/e` will be recognized as a particle species,
+          - but `/data/100/generations/2/particles/e` will not.
+
+        In this example, `/generations/[[:num:]]+/particles/` can be used
+        to refer to the particles found at different particle generations.
+      2. `/particles/e` refers only to this particular particle species relative
+        from the `basePath`. E.g., in a group-based file:
+
+          - `/data/100/particles/e` will be recognized as a particle species,
+          - but neither will `/data/50/particles/i`,
+          - nor will `/data/0/generations/2/particles/e`.
+
+      3. `particles/`: Any group with name `particles` contains only
+        particle species.
+        In a group-based file, this will recognize the following paths
+        as particle species:
+
+          - `/data/0/particles/e`
+          - `/data/100/generations/2/particles/e`
+
+    - Notes:
+
+        A single regex is technically sufficient since regexes can express
+        multiple options. However, using a list improves legibility and can
+        help tooling interpret user intent better (e.g. if the first list
+        entry is `fields/`, then an implementation can choose to use that
+        name by default instead of `particles/`).
+
+        The shorthand notation (format 3) corresponds with the openPMD 1.0
+        notation of particles paths.
+
+        No specific dialect of regular expressions is specified, but the
+        `egrep` style is recommended.
+        @TODO: Should we use a recommendation? Should we encode the style
+        as an attribute?
 
 It is *recommended* that each file's *root* group (path `/`) further
 contains the attributes:


### PR DESCRIPTION
*Please add a brief description (one sentence) here and link the issue this pull-request implements*

This is a suggestion for making openPMD markup be usable in a user-specified group hierarchy within an Iteration.

*Implements issue:* https://github.com/openPMD/openPMD-standard/issues/115

## Description

*As detailed description as possible.*

In principle, custom data can be introduced to openPMD datasets today already without the openPMD standard being any wiser about it, since the standard only describes what must be there. As a result, custom groups, datasets, attributes may be used today already.

With this PR, datasets will be able to profit from openPMD markup within such custom groups, e.g. meshes and particles can be placed in user-defined places within iterations now: 

![Bildschirmfoto vom 2023-09-12 11-01-36](https://github.com/openPMD/openPMD-standard/assets/14241876/a4a4a4ac-636f-4349-bc14-c4e4a2cc36a1)


*What is introduced, removed or renamed and why?*

The only change necessary to this end is a new definition of the `meshesPath` and `particlesPath` attributes. The new definition is defined to be backward compatible with the old definition, e.g. existing datasets using the openPMD 1.0 specification for e.g. `meshesPath` will still work with openPMD 2.0.

`meshesPath` and `particlesPath` are now lists of regular expressions. (This is technically redundant as regular expressions are powerful enough to represent "lists" (e1|e2|e3), but it reduces reliance on regular expressions, and the concept of "listing" paths is important enough to be explicitly expressed in the standard.)

This way, the `meshesPath` and `particlesPath` can list the locations where meshes and particles species may be found (either as a relative or an absolute path). 

*What is made required, recommended, optional?* 

It no longer makes sense to require that a mesh exists when the `meshesPath` is defined, likewise the `particlesPath` (regular expressions might in fact denote an infinite set of locations). 

*What concept stands behind this change?*

The fact that the openPMD standard is extensible and hierarchical. This proposal makes the openPMD standard aware of extended hierarchies and allows interacting with them.

*Please also add an example.*

-- will follow --

## Affected Components

- `base`
- any extension that intends to organize the meshes or species in some way (notably: mesh refinement)

## Logic Changes

*Which logic changes are conceptually introduced?*

## Writer Changes

*How does this change affect data writers?*

Not at all if the new features are not used.

*What would a writer need to change?*

It can optionally use the new features.

*Does this pull request change the interpretation of existing data writers?*

No.

- `libopenPMD`: The proposal is prototyped in https://github.com/openPMD/openPMD-api/pull/1432

## Reader Changes

*How does this change affect data readers?*

Data readers can no longer expect to have a single group containing meshes (likewise particles). Especially in the openPMD-api, the semantics of `iteration[0].meshes` become unclear when in fact the dataset contains `/data/0/fields` and `/data/0/images`.

Data readers need to traverse subdirectories if they intend to find all data.

The `meshesPath` and `particlesPath` attributes might now have values that old readers cannot interpret.

*What would a reader need to change? Link implementation examples!*

- `libopenPMD`: The proposal is prototyped in https://github.com/openPMD/openPMD-api/pull/1432

- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `XDMF` (upcoming): https://github.com/openPMD/openPMD-tools/...

## Data Converter

*How does this affect already existing files with previous versions of the standard?*

Not at all.

*Is this change possible to be expressed in a way, that an automated tool can update the file?*
*Link code/pull requests that implement the upgrade logic!*

Not necessary.

- https://github.com/openPMD/openPMD-converter/...


# Discussion:

* Should we use regular expressions at all? List of strings might also suffice. Otherwise, bash-like globbing might be a good compromise, but we might need to implement it manually.
* We might wish to drop option (2) for denoting a mesh/particle species (full path to the mesh/species itself) for the sake of simplicity. This will mean that the `meshesPath`/`particlesPath` can only refer to the parent group that *contains* meshes/species (as it does now), implying that any group can contain only (meshes XOR particles XOR custom subgroups). With the current design, mixing them is possible.
* Alternative approach: Keep the definition of `meshesPath` and `particlesPath` as it is now, but allow overriding the `meshesPath` and `particlesPath` at each level of the hierarchy. Maybe allow specifying lists, so that things like `/data/0/meshes` and `/data/0/images` can be meshes in the same dataset. 
  This approach has the advantage of being simpler and having increased forward compatibility, since the "new" features can be better contained in places where old readers don't see them. The `meshesPath` and `particlesPath` attributes become less monolithic, i.e. the location of meshes and particles are not described in one single place inside an attribute with rather complicated semantics.
