### PR TITLE
Particle Weight: Clarify Low-D Dimension

### DIFF
--- a/EXT_ParticleWeighting.md
+++ b/EXT_ParticleWeighting.md
@@ -80,6 +80,8 @@ shall be used.
     - description: the number of underlying individual particles that
                    the macroparticles represent
     - advice to implementors: must have `weightingPower = 1`,
-                              `macroWeighted = 1`, `unitSI = 1` and
-                              `unitDimension == (0., ..., 0.)`
+                              `macroWeighted = 1`, `unitSI = 1`.
+                              `unitDimension` is a unitless count in 3D geometries `(0., ..., 0.)`
+                              but can be a count per length `(-1., ..., 0.)` or
+                              per surface area `(-2., ..., 0.)` in lower dimensions.
 


### PR DESCRIPTION
## Description

Although a count in 3D geometries, this is a count per length and a count per area in 2D or 1D.

## Affected Components

- `EXT-ParticleWeighting`

## Logic Changes

Just corrects a comment to implementers.

## Writer Changes

N/A

## Reader Changes

N/A

## Data Converter

N/A
