### PR TITLE
distinguish between W+ and W- in particle type

### DIFF
--- a/EXT_SpeciesType.md
+++ b/EXT_SpeciesType.md
@@ -59,7 +59,8 @@ Leptons:
 Gauge & Higgs Bosons:
   - `photon`
   - `gluon`
-  - `w-boson`
+  - `w-plus-boson`
+  - `w-minus-boson`
   - `z-boson`
   - `higgs`
 


### PR DESCRIPTION
distinguish between W+ and W- boson in particle type extension

*Implements issue:* #287 

## Description

Replaces the particle type `w-boson` with `w-plus-boson` and `w-minus-boson` in the particle type extension of openPMD.

This makes it possible to distinguish the differing electric charges of W+ and W- bosons and aligns them with the rest of particles.

## Affected Components

- `EXT-SpeciesType`

## Logic Changes

non

## Writer Changes

separate between W+ and W- bosons

## Reader Changes

remove one SpeciesType and add two new SpeciesType

- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...
- `XDMF` (upcoming): https://github.com/openPMD/openPMD-tools/...

## Data Converter

change speciesType from `w-boson` to either `w-plus-boson` or `w-minus-boson`
2.0 is not yet released, so no change needed from 1.X.
