### PR TITLE
Const Records: Relax `shape` for Particles

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -731,8 +731,10 @@ The record's *data set* `<componentName>` must be replaced with an empty
 
 `shape` is a 1-dimensional array of `N` *(uint64)* elements, where `N` is the
 number of dimensions of the record. It contains the number of elements of each
-dimension that are replaced with a constant value. For `mesh` based records,
-the order of the `N` values must be identical to the axes in `axisLabels`.
+dimension that are replaced with a constant value.
+  - For `mesh` based records, the order of the `N` values must be identical to the axes in `axisLabels`.
+  - For `particle` records, the `shape` attribute can be skipped if there is *at least one more record* in the same particle group (species) that is non-constant or is constant and has the `shape` attribute.
+    Read-logic will then pick any other record to recover the `shape`.
 
 Other required attributes that where previously stored on the *data set* need
 to be added to the new sub-group as well.

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -733,8 +733,8 @@ The record's *data set* `<componentName>` must be replaced with an empty
 number of dimensions of the record. It contains the number of elements of each
 dimension that are replaced with a constant value.
   - For `mesh` based records, the order of the `N` values must be identical to the axes in `axisLabels`.
-  - For `particle` records, the `shape` attribute can be skipped if there is *at least one more record* in the same particle group (species) that is non-constant or is constant and has the `shape` attribute.
-    Read-logic will then pick any other record to recover the `shape`.
+  - The `shape` attribute can be skipped if there is *at least one more record component* in the same mesh record or particle group (species) that is non-constant or is constant and has the `shape` attribute.
+    Read-logic will then pick any other record component of the same mesh (or particle species) to recover the `shape`.
 
 Other required attributes that where previously stored on the *data set* need
 to be added to the new sub-group as well.


### PR DESCRIPTION
## Description

For MPI-parallel I/O output, we developed a new method in ADIOS2 that does not need an initial metadata gather ("JoinedArrays"). To be able to use this mode, we need to relax the requirements to write a shape for constant records in a species (particle group), because otherwise we still have to do a collective gather.

This adds the need for a slight additional read fallback implementation on the reader side.

## Affected Components

- `base`

## Logic Changes

The required attribute `shape` in constant record components is now optional for records in particle groups (species), if there is at least another record to recover the `shape` from in the same particle species.

## Writer Changes

The required attribute `shape` in constant record components is now optional for records in particle groups (species).

## Reader Changes

The required attribute `shape` in constant record components is now optional for records in particle groups (species).
 If the attribute is missing, go through other records and components of the same species and pick the first one that has a `shape` (e.g., non-constant record component full extent or a constant record component with a `shape`) and use that information to recover.

*What would a reader need to change? Link implementation examples!*

- [ ]  `openPMD-api`: https://github.com/openPMD/openPMD-api/issues/1663 https://github.com/openPMD/openPMD-api/pull/1661 @franzpoeschel 
  - [x]  `yt`: https://github.com/yt-project/yt/... - will be based on openPMD-api soon
  - [x]  `ParaView`: based on openPMD-api
  - [x]  `openPMD-viewer`: base on openPMD-api for ADIOS2
- [ ] `openPMD-validator`: https://github.com/openPMD/openPMD-validator/... @ax3l 
- [ ]  `VisIt`: https://github.com/openPMD/openPMD-visit-plugin/...

## Data Converter

No changes needed. Files from `1.X` will be forward compatible with regards to this change.